### PR TITLE
Add admin-only System Health dashboard

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,10 +1,11 @@
 import json
 import os
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Dict, Any
 
-from sqlalchemy import create_engine, Column, String, DateTime, Text, desc, Index, ForeignKey
+from sqlalchemy import create_engine, Column, String, DateTime, Text, desc, Index, ForeignKey, event
 from sqlalchemy.orm import sessionmaker, declarative_base
 
 # Support external database via DATABASE_URL (e.g., Supabase Postgres). Fallback to SQLite.
@@ -19,6 +20,69 @@ else:
     engine = create_engine("sqlite:////app/data/app.db", future=True)
 SessionLocal = sessionmaker(bind=engine, expire_on_commit=False, autoflush=False)
 Base = declarative_base()
+
+
+# ---- system_health: register engine + emit per-query latency samples ----
+def _install_db_health_hooks():
+    try:
+        from app import system_health as _sh
+    except Exception:
+        return
+    try:
+        _sh.attach_db_engine(engine)
+    except Exception:
+        pass
+
+    def _before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        try:
+            context._sh_started = time.perf_counter()
+        except Exception:
+            pass
+
+    def _after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        try:
+            started = getattr(context, "_sh_started", None)
+            if started is None:
+                return
+            ms = (time.perf_counter() - started) * 1000.0
+            # Derive a short op name from the SQL: first verb + table-like hint
+            try:
+                s = (statement or "").lstrip()
+                verb = s.split(None, 1)[0].upper()[:8] if s else "SQL"
+                op = verb
+                # Try to grab the first table-ish token after FROM/INTO/UPDATE
+                upper = s.upper()
+                hint = None
+                for kw in (" FROM ", " INTO ", "UPDATE "):
+                    idx = upper.find(kw)
+                    if idx >= 0:
+                        rest = s[idx + len(kw):]
+                        hint = rest.split(None, 1)[0].strip(" ,()`\"';").lower()
+                        break
+                if hint:
+                    op = f"{verb} {hint}"
+            except Exception:
+                op = "SQL"
+            _sh.record("db", op, ms, True)
+        except Exception:
+            pass
+
+    def _handle_error(exception_context):
+        try:
+            # We don't have timing for errored queries reliably; record a 0ms err sample.
+            _sh.record("db", "ERROR", 0.0, False, error=f"{type(exception_context.original_exception).__name__}: {exception_context.original_exception}")
+        except Exception:
+            pass
+
+    try:
+        event.listen(engine, "before_cursor_execute", _before_cursor_execute)
+        event.listen(engine, "after_cursor_execute", _after_cursor_execute)
+        event.listen(engine, "handle_error", _handle_error)
+    except Exception:
+        pass
+
+
+_install_db_health_hooks()
 
 
 class Test(Base):

--- a/backend/app/integrations/clarity_client.py
+++ b/backend/app/integrations/clarity_client.py
@@ -224,12 +224,38 @@ def fetch_project_live_insights(
     for i, dim in enumerate(dims, start=1):
         params[f"dimension{i}"] = dim
 
-    res = requests.get(
-        CLARITY_EXPORT_URL,
-        params=params,
-        headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json"},
-        timeout=30,
-    )
+    _sh_record = None
+    try:
+        from app.system_health import record as _sh_record  # type: ignore
+    except Exception:
+        _sh_record = None
+    import time as _t
+    _started = _t.perf_counter()
+    _ok = True
+    _err = None
+    try:
+        res = requests.get(
+            CLARITY_EXPORT_URL,
+            params=params,
+            headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json"},
+            timeout=30,
+        )
+        try:
+            if int(getattr(res, "status_code", 0) or 0) >= 500:
+                _ok = False
+                _err = f"HTTP {res.status_code}"
+        except Exception:
+            pass
+    except BaseException as _e:
+        _ok = False
+        _err = f"{type(_e).__name__}: {_e}"
+        raise
+    finally:
+        if _sh_record is not None:
+            try:
+                _sh_record("clarity", "fetch_project_live_insights", (_t.perf_counter() - _started) * 1000.0, _ok, error=_err)
+            except Exception:
+                pass
     if res.status_code >= 400:
         raise RuntimeError(f"Clarity API error {res.status_code}: {res.text[:300]}")
     data = res.json()

--- a/backend/app/integrations/gemini_client.py
+++ b/backend/app/integrations/gemini_client.py
@@ -736,3 +736,58 @@ def gen_variant_images_from_image(
             })
         items.append({"kind": "composite", "image": image_url, "prompt": "fallback"})
         return items
+
+
+# ---- system_health instrumentation -------------------------------------------------
+# Wrap the public generate/analyze functions so the System Health dashboard sees
+# Gemini latency, error rate, and recent failures.
+def _install_gemini_health_hooks():
+    import time as _t
+    try:
+        from app.system_health import record as _sh_record
+    except Exception:
+        return
+
+    def _wrap(name: str) -> None:
+        original = globals().get(name)
+        if not callable(original):
+            return
+
+        def wrapped(*args, **kwargs):
+            started = _t.perf_counter()
+            ok = True
+            err = None
+            try:
+                return original(*args, **kwargs)
+            except BaseException as e:
+                ok = False
+                err = f"{type(e).__name__}: {e}"
+                raise
+            finally:
+                try:
+                    _sh_record("gemini", name, (_t.perf_counter() - started) * 1000.0, ok, error=err)
+                except Exception:
+                    pass
+
+        try:
+            wrapped.__name__ = name
+            wrapped.__doc__ = getattr(original, "__doc__", None)
+        except Exception:
+            pass
+        globals()[name] = wrapped
+
+    for fn_name in (
+        "gen_ad_images_from_image",
+        "gen_clean_wholesale_product_image",
+        "gen_promotional_images_from_angles",
+        "gen_feature_benefit_images",
+        "analyze_variants_from_image",
+        "gen_variant_images_from_image",
+    ):
+        try:
+            _wrap(fn_name)
+        except Exception:
+            pass
+
+
+_install_gemini_health_hooks()

--- a/backend/app/integrations/meta_client.py
+++ b/backend/app/integrations/meta_client.py
@@ -1,9 +1,54 @@
-import os, json, requests
+import os, json, time, requests
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 from tenacity import retry, stop_after_attempt, wait_exponential
 from dotenv import load_dotenv
 load_dotenv()
+
+
+def _timed_meta_request(method: str, url: str, **kw):
+    """``requests.<verb>`` wrapper that records a system_health sample on the ``meta`` provider."""
+    import inspect as _inspect
+    try:
+        from app.system_health import record as _sh_record
+    except Exception:
+        _sh_record = None  # type: ignore
+
+    op_name = method
+    try:
+        frame = _inspect.currentframe()
+        if frame and frame.f_back:
+            op_name = frame.f_back.f_code.co_name or method
+    except Exception:
+        op_name = method
+
+    started = time.perf_counter()
+    ok = True
+    err = None
+    try:
+        r = requests.request(method, url, **kw)
+        try:
+            sc = int(getattr(r, "status_code", 0) or 0)
+            if sc >= 500:
+                ok = False
+                err = f"HTTP {sc}"
+            elif sc == 429:
+                ok = False
+                err = "HTTP 429 (rate-limited)"
+        except Exception:
+            pass
+        return r
+    except BaseException as e:
+        ok = False
+        err = f"{type(e).__name__}: {e}"
+        raise
+    finally:
+        if _sh_record is not None:
+            try:
+                ms = (time.perf_counter() - started) * 1000.0
+                _sh_record("meta", op_name, ms, ok, error=err)
+            except Exception:
+                pass
 
 ACCESS = os.getenv("META_ACCESS_TOKEN", "")
 AD_ACCOUNT_ID = os.getenv("META_AD_ACCOUNT_ID", "")  # numeric only, no act_
@@ -69,7 +114,7 @@ def _post(path: str, payload: dict, files=None):
     payload = {**payload, "access_token": ACCESS}
     url = f"{BASE}/{path}"
     try:
-        r = requests.post(url, data=payload, files=files, timeout=120)
+        r = _timed_meta_request("POST", url, data=payload, files=files, timeout=120)
         r.raise_for_status()
         return r.json()
     except requests.HTTPError as e:
@@ -79,7 +124,7 @@ def _get(path: str, params: dict | None = None):
     params = {**(params or {}), "access_token": ACCESS}
     url = f"{BASE}/{path}"
     try:
-        r = requests.get(url, params=params, timeout=120)
+        r = _timed_meta_request("GET", url, params=params, timeout=120)
         r.raise_for_status()
         return r.json()
     except requests.HTTPError as e:

--- a/backend/app/integrations/openai_client.py
+++ b/backend/app/integrations/openai_client.py
@@ -11,6 +11,64 @@ client = OpenAI()
 DEFAULT_LLM_MODEL = os.getenv("OPENAI_MODEL", "gpt-5")
 DEFAULT_IMAGE_MODEL = os.getenv("OPENAI_IMAGE_MODEL", "gpt-image-2")
 
+
+# ---- system_health instrumentation -------------------------------------------------
+# Wrap the few OpenAI SDK methods this app actually calls so the System Health
+# dashboard can report p50/p95/p99 + error rate per provider. Pure-additive:
+# if anything goes wrong wiring this, the underlying calls keep working.
+def _install_openai_health_hooks():
+    import time as _t
+    try:
+        from app.system_health import record as _sh_record
+    except Exception:
+        return
+
+    def _wrap(method, category, op):
+        def wrapped(*a, **kw):
+            started = _t.perf_counter()
+            ok = True
+            err = None
+            try:
+                return method(*a, **kw)
+            except BaseException as e:
+                ok = False
+                err = f"{type(e).__name__}: {e}"
+                raise
+            finally:
+                try:
+                    _sh_record(category, op, (_t.perf_counter() - started) * 1000.0, ok, error=err)
+                except Exception:
+                    pass
+        try:
+            wrapped.__name__ = getattr(method, "__name__", op)
+        except Exception:
+            pass
+        return wrapped
+
+    try:
+        orig = client.chat.completions.create
+        client.chat.completions.create = _wrap(orig, "openai", "chat.completions.create")
+    except Exception:
+        pass
+    try:
+        orig = client.responses.create  # newer SDK surface
+        client.responses.create = _wrap(orig, "openai", "responses.create")
+    except Exception:
+        pass
+    try:
+        orig = client.images.generate
+        client.images.generate = _wrap(orig, "openai_image", "images.generate")
+    except Exception:
+        pass
+    try:
+        orig = client.images.edit
+        client.images.edit = _wrap(orig, "openai_image", "images.edit")
+    except Exception:
+        pass
+
+
+_install_openai_health_hooks()
+
 ANGLE_JSON_INSTRUCTIONS = {"type": "json_object"}
 
 # We build the prompt with an f-string so that only the payload vars are substituted and

--- a/backend/app/integrations/shopify_client.py
+++ b/backend/app/integrations/shopify_client.py
@@ -19,6 +19,59 @@ _PRODUCT_BRIEF_WORKERS = int(os.getenv("PTOS_PRODUCTS_BRIEF_WORKERS", "8") or "8
 _UTM_ORDERS_DB_TTL_S = int(os.getenv("PTOS_UTM_ORDERS_DB_TTL_S", "300") or "300")  # 5 minutes
 _perf_log = logging.getLogger("shopify_client.perf")
 
+
+def _timed_request(method: str, url: str, **kw):
+    """Drop-in replacement for ``requests.<verb>`` that records a system_health sample.
+
+    Op label is the calling helper's function name (e.g. ``_gql_store``,
+    ``_rest_get_store_raw``). Status >= 500 counts as an error sample.
+    Network exceptions count as errors. Pure-additive: any failure inside
+    recording is swallowed so it can never break the request.
+    """
+    import inspect as _inspect
+    try:
+        from app.system_health import record as _sh_record
+    except Exception:
+        _sh_record = None  # type: ignore
+
+    op_name = method
+    try:
+        frame = _inspect.currentframe()
+        if frame and frame.f_back:
+            op_name = frame.f_back.f_code.co_name or method
+    except Exception:
+        op_name = method
+
+    started = time.perf_counter()
+    ok = True
+    err = None
+    status_code = None
+    try:
+        r = requests.request(method, url, **kw)
+        try:
+            status_code = int(getattr(r, "status_code", 0) or 0)
+            if status_code >= 500:
+                ok = False
+                err = f"HTTP {status_code}"
+            elif status_code == 429:
+                # Surface rate-limit as a soft error so the dashboard catches it
+                ok = False
+                err = "HTTP 429 (rate-limited)"
+        except Exception:
+            pass
+        return r
+    except BaseException as e:
+        ok = False
+        err = f"{type(e).__name__}: {e}"
+        raise
+    finally:
+        if _sh_record is not None:
+            try:
+                ms = (time.perf_counter() - started) * 1000.0
+                _sh_record("shopify", op_name, ms, ok, error=err)
+            except Exception:
+                pass
+
 def _canonical_store_label(store: str | None) -> str | None:
     s = (store or "").strip().lower()
     if not s:
@@ -285,7 +338,7 @@ def _gql(query: str, variables: dict):
             auth = (API_KEY, PASSWORD)
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD.")
-    r = requests.post(GQL, headers=headers, json={"query": query, "variables": variables}, timeout=60, auth=auth)
+    r = _timed_request("POST",GQL, headers=headers, json={"query": query, "variables": variables}, timeout=60, auth=auth)
     r.raise_for_status()
     j = r.json()
     if "errors" in j:
@@ -314,7 +367,7 @@ def _rest_post(path: str, payload: dict):
             auth = (API_KEY, PASSWORD)
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD.")
-    r = requests.post(url, headers=headers, json=payload, timeout=60, auth=auth)
+    r = _timed_request("POST",url, headers=headers, json=payload, timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -331,7 +384,7 @@ def _rest_get(path: str):
             auth = (API_KEY, PASSWORD)
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD.")
-    r = requests.get(url, headers=headers, timeout=60, auth=auth)
+    r = _timed_request("GET",url, headers=headers, timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -347,7 +400,7 @@ def _rest_put(path: str, payload: dict):
             auth = (API_KEY, PASSWORD)
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD.")
-    r = requests.put(url, headers=headers, json=payload, timeout=60, auth=auth)
+    r = _timed_request("PUT",url, headers=headers, json=payload, timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -363,7 +416,7 @@ def _rest_delete(path: str):
             auth = (API_KEY, PASSWORD)
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD.")
-    r = requests.delete(url, headers=headers, timeout=60, auth=auth)
+    r = _timed_request("DELETE",url, headers=headers, timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -377,7 +430,7 @@ def _gql_store(store: str | None, query: str, variables: dict):
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.post(cfg["GQL"], headers=cfg["HEADERS"], json={"query": query, "variables": variables}, timeout=60, auth=auth)
+    r = _timed_request("POST",cfg["GQL"], headers=cfg["HEADERS"], json={"query": query, "variables": variables}, timeout=60, auth=auth)
     r.raise_for_status()
     j = r.json()
     if "errors" in j:
@@ -404,7 +457,7 @@ def _gql_store_once(store: str | None, query: str, variables: dict, *, timeout: 
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.post(cfg["GQL"], headers=cfg["HEADERS"], json={"query": query, "variables": variables}, timeout=timeout, auth=auth)
+    r = _timed_request("POST",cfg["GQL"], headers=cfg["HEADERS"], json={"query": query, "variables": variables}, timeout=timeout, auth=auth)
     r.raise_for_status()
     j = r.json()
     if "errors" in j:
@@ -420,7 +473,7 @@ def _rest_post_store(store: str | None, path: str, payload: dict):
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.post(url, headers=cfg["HEADERS"], json=payload, timeout=60, auth=auth)
+    r = _timed_request("POST",url, headers=cfg["HEADERS"], json=payload, timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -434,7 +487,7 @@ def _rest_get_store(store: str | None, path: str):
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.get(url, headers=cfg["HEADERS"], timeout=60, auth=auth)
+    r = _timed_request("GET",url, headers=cfg["HEADERS"], timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -449,7 +502,7 @@ def _rest_get_store_raw(store: str | None, path: str):
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.get(url, headers=cfg["HEADERS"], timeout=60, auth=auth, allow_redirects=False)
+    r = _timed_request("GET",url, headers=cfg["HEADERS"], timeout=60, auth=auth, allow_redirects=False)
     r.raise_for_status()
     return r
 
@@ -463,7 +516,7 @@ def _rest_get_store_raw_once(store: str | None, path: str, *, timeout: int = 20)
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.get(url, headers=cfg["HEADERS"], timeout=timeout, auth=auth, allow_redirects=False)
+    r = _timed_request("GET",url, headers=cfg["HEADERS"], timeout=timeout, auth=auth, allow_redirects=False)
     r.raise_for_status()
     return r
 
@@ -512,7 +565,7 @@ def _rest_put_store(store: str | None, path: str, payload: dict):
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.put(url, headers=cfg["HEADERS"], json=payload, timeout=60, auth=auth)
+    r = _timed_request("PUT",url, headers=cfg["HEADERS"], json=payload, timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 
@@ -525,7 +578,7 @@ def _rest_delete_store(store: str | None, path: str):
             auth = (cfg["API_KEY"], cfg["PASSWORD"])
         else:
             raise RuntimeError("Provide either SHOPIFY_ACCESS_TOKEN or both SHOPIFY_API_KEY and SHOPIFY_PASSWORD for the selected store.")
-    r = requests.delete(url, headers=cfg["HEADERS"], timeout=60, auth=auth)
+    r = _timed_request("DELETE",url, headers=cfg["HEADERS"], timeout=60, auth=auth)
     r.raise_for_status()
     return r.json() if r.content else {}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -99,6 +99,13 @@ except Exception:
 
 app = FastAPI(title="Product Testing OS", version="0.1.0")
 
+# System health metrics middleware — pure-additive, fails closed (never blocks request)
+from app.system_health import HealthMiddleware as _HealthMiddleware  # noqa: E402
+from app.system_health_routes import router as _system_health_router  # noqa: E402
+from app import system_health as _sh  # noqa: E402
+app.add_middleware(_HealthMiddleware)
+app.include_router(_system_health_router)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -1172,16 +1179,25 @@ async def create_test(
 
     # Run synchronously by default unless USE_CELERY is explicitly enabled
     use_celery = os.getenv("USE_CELERY", "false").lower() in ("1", "true", "yes")
+
+    def _tracked_pipeline_run(_tid: str, _payload: dict):
+        _sh.register_inflight(f"pipeline:{_tid}", "pipeline", store=(_payload or {}).get("store"), label=f"test {_tid}")
+        try:
+            with _sh.time_op("pipeline", "run_pipeline_sync", store=(_payload or {}).get("store")):
+                run_pipeline_sync(_tid, _payload)
+        finally:
+            _sh.clear_inflight(f"pipeline:{_tid}")
+
     if not use_celery:
         import threading
-        threading.Thread(target=run_pipeline_sync, args=(test_id, payload), daemon=True).start()
+        threading.Thread(target=_tracked_pipeline_run, args=(test_id, payload), daemon=True).start()
     else:
         try:
             pipeline_launch.delay(test_id, payload)
         except Exception:
             # If enqueue fails (e.g., no broker), fall back to sync so tests aren't stuck
             import threading
-            threading.Thread(target=run_pipeline_sync, args=(test_id, payload), daemon=True).start()
+            threading.Thread(target=_tracked_pipeline_run, args=(test_id, payload), daemon=True).start()
 
     return {"test_id": test_id, "status": "queued"}
 
@@ -2518,7 +2534,15 @@ async def api_campaign_analyze(req: CampaignAnalyzeRequest):
             "campaign_name": (req.campaign_name or "").strip(),
         }
 
-        thread = threading.Thread(target=_run_analysis_job, args=(job_id, req_data), daemon=True)
+        def _tracked_analysis(_jid: str, _rd: dict):
+            _sh.register_inflight(f"analysis:{_jid}", "campaign_analysis", store=(_rd or {}).get("store"), label=f"analysis {_jid}")
+            try:
+                with _sh.time_op("pipeline", "run_analysis_job", store=(_rd or {}).get("store")):
+                    _run_analysis_job(_jid, _rd)
+            finally:
+                _sh.clear_inflight(f"analysis:{_jid}")
+
+        thread = threading.Thread(target=_tracked_analysis, args=(job_id, req_data), daemon=True)
         thread.start()
 
         return {"job_id": job_id}
@@ -2600,8 +2624,16 @@ async def api_generate_action_tasks(req: GenerateActionTasksRequest):
             for old_key in keys[:len(keys) - 20]:
                 _action_task_jobs.pop(old_key, None)
 
+        def _tracked_action_tasks(_jid: str, _analyses, _store):
+            _sh.register_inflight(f"action_tasks:{_jid}", "action_tasks", store=_store, label=f"action_tasks {_jid}")
+            try:
+                with _sh.time_op("pipeline", "run_action_task_job", store=_store):
+                    _run_action_task_job(_jid, _analyses, _store)
+            finally:
+                _sh.clear_inflight(f"action_tasks:{_jid}")
+
         thread = threading.Thread(
-            target=_run_action_task_job,
+            target=_tracked_action_tasks,
             args=(job_id, req.analyses, req.store),
             daemon=True,
         )
@@ -3104,9 +3136,17 @@ async def api_analyze_all_campaigns(req: BulkAnalyzeRequest):
             "date_range": {"start": s_date, "end": e_date},
         })
 
+        def _tracked_bulk(_jid: str, _store, _accts, _s, _e):
+            _sh.register_inflight(f"bulk_analysis:{_jid}", "bulk_analysis", store=_store, label=f"bulk_analysis {_jid}")
+            try:
+                with _sh.time_op("pipeline", "run_bulk_analysis_job", store=_store):
+                    _run_bulk_analysis_job(_jid, _store, _accts, _s, _e)
+            finally:
+                _sh.clear_inflight(f"bulk_analysis:{_jid}")
+
         # Launch background thread (daemon=False so it survives request lifecycle)
         thread = threading.Thread(
-            target=_run_bulk_analysis_job,
+            target=_tracked_bulk,
             args=(job_id, store, (req.ad_accounts or ([req.ad_account] if req.ad_account else [])), s_date, e_date),
             daemon=False,
             name=f"bulk-analysis-{job_id[:8]}",
@@ -5272,7 +5312,15 @@ async def api_ads_launch(req: AdsAutomationLaunchRequest):
             "num_angles": req.num_angles or 3,
             "model": req.model,
         }
-        t = threading.Thread(target=run_ads_automation_sync, args=(req.flow_id, payload), daemon=True)
+        def _tracked_ads(_fid: str, _pl: dict):
+            _sh.register_inflight(f"ads_automation:{_fid}", "ads_automation", store=None, label=f"ads {_fid}")
+            try:
+                with _sh.time_op("pipeline", "run_ads_automation_sync"):
+                    run_ads_automation_sync(_fid, _pl)
+            finally:
+                _sh.clear_inflight(f"ads_automation:{_fid}")
+
+        t = threading.Thread(target=_tracked_ads, args=(req.flow_id, payload), daemon=True)
         t.start()
         return {"flow_id": req.flow_id, "status": "queued"}
     except Exception as e:

--- a/backend/app/system_health.py
+++ b/backend/app/system_health.py
@@ -1,0 +1,960 @@
+"""
+System Health monitoring for Product Testing OS.
+
+Pure-additive, in-memory, bounded telemetry. Records:
+  - per-request latency, tagged by surface (ads_management, confirmation,
+    page_builder, theme_editor, wholesale, …) via an ASGI middleware
+  - per-provider outbound HTTP latency (Shopify, Meta, OpenAI, Gemini, Clarity)
+  - DB query latency via SQLAlchemy events + pool checkout stats
+  - in-flight pipelines / analysis jobs / ad-automation threads
+  - Celery broker reachability + queue depth (best-effort)
+  - process stats: RSS, threads, asyncio tasks, threadpool slots
+
+All state lives in process memory. No new dependencies, no new database
+tables. Rings have a hard size cap; metric collection adds microseconds per
+call. The dashboard polls these endpoints; nothing else depends on this
+module — failures are swallowed so instrumentation can never break a hot
+path.
+
+================================================================
+Tunable env vars (all optional; integers unless noted)
+================================================================
+
+Sample sizing
+  HEALTH_RING_SIZE                 (500)   samples per (category,op) ring
+  HEALTH_ERR_RING_SIZE             (50)    last errors per provider
+  HEALTH_SLOWOPS_SIZE              (100)   global slow-ops feed cap
+  HEALTH_MIN_SAMPLES               (5)     min samples before p95 evaluation
+  HEALTH_WINDOW_S                  (600)   aggregation window in seconds
+  HEALTH_SAMPLES_WINDOW_S          (3600)  hard retention window for samples
+
+Latency thresholds (p95, milliseconds — warn,crit)
+  HEALTH_SHOPIFY_P95_WARN_MS       (1500)
+  HEALTH_SHOPIFY_P95_CRIT_MS       (4000)
+  HEALTH_META_P95_WARN_MS          (3000)
+  HEALTH_META_P95_CRIT_MS          (8000)
+  HEALTH_OPENAI_P95_WARN_MS        (5000)
+  HEALTH_OPENAI_P95_CRIT_MS        (20000)
+  HEALTH_OPENAI_IMG_P95_WARN_MS    (20000)
+  HEALTH_OPENAI_IMG_P95_CRIT_MS    (60000)
+  HEALTH_GEMINI_P95_WARN_MS        (5000)
+  HEALTH_GEMINI_P95_CRIT_MS        (20000)
+  HEALTH_CLARITY_P95_WARN_MS       (5000)
+  HEALTH_CLARITY_P95_CRIT_MS       (15000)
+  HEALTH_DB_P95_WARN_MS            (100)
+  HEALTH_DB_P95_CRIT_MS            (500)
+  HEALTH_REQ_P95_WARN_MS           (2000)
+  HEALTH_REQ_P95_CRIT_MS           (8000)
+
+Error-rate thresholds (0..1, decimals)
+  HEALTH_PROVIDER_ERR_RATE_WARN    (0.10)
+  HEALTH_PROVIDER_ERR_RATE_CRIT    (0.30)
+
+Pipeline & queue thresholds
+  HEALTH_INFLIGHT_PIPELINES_WARN   (5)
+  HEALTH_INFLIGHT_PIPELINES_CRIT   (15)
+  HEALTH_PIPELINE_STALE_S          (1800)  in-flight pipeline older than this is "stuck"
+  HEALTH_CELERY_QUEUE_WARN         (20)
+  HEALTH_CELERY_QUEUE_CRIT         (100)
+
+Confirmation SLA
+  HEALTH_CONFIRMATION_STUCK_HOURS  (24)    open+assigned without n/wtp action for X hours
+  HEALTH_CONFIRMATION_STUCK_WARN   (10)
+  HEALTH_CONFIRMATION_STUCK_CRIT   (50)
+  HEALTH_CONFIRMATION_PROBE_TTL_S  (300)   cache TTL for the stuck-orders probe
+
+Process / memory
+  HEALTH_RSS_WARN_MB               (350)
+  HEALTH_RSS_CRIT_MB               (480)
+
+Auth
+  SYSTEM_ADMIN_USERS              (JSON map or array — see system_health_routes.py)
+  SYSTEM_ADMIN_SECRET             (signing secret for tokens; falls back to JWT_SECRET)
+
+Misc
+  HEALTH_EXCLUDE_ROUTES           (comma-sep prefixes excluded from request timing;
+                                   default: /uploads,/health,/api/system-health,/favicon.ico)
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import threading
+import time
+from collections import deque
+from typing import Any, Callable, Iterable, Optional
+
+_log = logging.getLogger("app.system_health")
+
+
+# ---------------- env helpers ----------------
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        v = os.getenv(name, "")
+        return int(v) if v not in (None, "") else default
+    except Exception:
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    try:
+        v = os.getenv(name, "")
+        return float(v) if v not in (None, "") else default
+    except Exception:
+        return default
+
+
+# ---------------- configuration ----------------
+
+RING_SIZE = _int_env("HEALTH_RING_SIZE", 500)
+ERR_RING_SIZE = _int_env("HEALTH_ERR_RING_SIZE", 50)
+SLOWOPS_SIZE = _int_env("HEALTH_SLOWOPS_SIZE", 100)
+MIN_SAMPLES = _int_env("HEALTH_MIN_SAMPLES", 5)
+WINDOW_S = _int_env("HEALTH_WINDOW_S", 600)
+SAMPLES_WINDOW_S = _int_env("HEALTH_SAMPLES_WINDOW_S", 3600)
+
+THRESHOLDS_MS: dict[str, tuple[int, int]] = {
+    "shopify":      (_int_env("HEALTH_SHOPIFY_P95_WARN_MS", 1500), _int_env("HEALTH_SHOPIFY_P95_CRIT_MS", 4000)),
+    "meta":         (_int_env("HEALTH_META_P95_WARN_MS", 3000),    _int_env("HEALTH_META_P95_CRIT_MS", 8000)),
+    "openai":       (_int_env("HEALTH_OPENAI_P95_WARN_MS", 5000),  _int_env("HEALTH_OPENAI_P95_CRIT_MS", 20000)),
+    "openai_image": (_int_env("HEALTH_OPENAI_IMG_P95_WARN_MS", 20000), _int_env("HEALTH_OPENAI_IMG_P95_CRIT_MS", 60000)),
+    "gemini":       (_int_env("HEALTH_GEMINI_P95_WARN_MS", 5000),  _int_env("HEALTH_GEMINI_P95_CRIT_MS", 20000)),
+    "clarity":      (_int_env("HEALTH_CLARITY_P95_WARN_MS", 5000), _int_env("HEALTH_CLARITY_P95_CRIT_MS", 15000)),
+    "db":           (_int_env("HEALTH_DB_P95_WARN_MS", 100),       _int_env("HEALTH_DB_P95_CRIT_MS", 500)),
+    "request":      (_int_env("HEALTH_REQ_P95_WARN_MS", 2000),     _int_env("HEALTH_REQ_P95_CRIT_MS", 8000)),
+}
+
+ERR_RATE_WARN = _float_env("HEALTH_PROVIDER_ERR_RATE_WARN", 0.10)
+ERR_RATE_CRIT = _float_env("HEALTH_PROVIDER_ERR_RATE_CRIT", 0.30)
+
+INFLIGHT_WARN = _int_env("HEALTH_INFLIGHT_PIPELINES_WARN", 5)
+INFLIGHT_CRIT = _int_env("HEALTH_INFLIGHT_PIPELINES_CRIT", 15)
+PIPELINE_STALE_S = _int_env("HEALTH_PIPELINE_STALE_S", 1800)
+CELERY_QUEUE_WARN = _int_env("HEALTH_CELERY_QUEUE_WARN", 20)
+CELERY_QUEUE_CRIT = _int_env("HEALTH_CELERY_QUEUE_CRIT", 100)
+
+CONFIRMATION_STUCK_HOURS = _int_env("HEALTH_CONFIRMATION_STUCK_HOURS", 24)
+CONFIRMATION_STUCK_WARN = _int_env("HEALTH_CONFIRMATION_STUCK_WARN", 10)
+CONFIRMATION_STUCK_CRIT = _int_env("HEALTH_CONFIRMATION_STUCK_CRIT", 50)
+CONFIRMATION_PROBE_TTL_S = _int_env("HEALTH_CONFIRMATION_PROBE_TTL_S", 300)
+
+RSS_WARN_MB = _int_env("HEALTH_RSS_WARN_MB", 350)
+RSS_CRIT_MB = _int_env("HEALTH_RSS_CRIT_MB", 480)
+
+_DEFAULT_EXCLUDES = "/uploads,/health,/api/system-health,/favicon.ico"
+EXCLUDE_ROUTES: tuple[str, ...] = tuple(
+    p.strip() for p in (os.getenv("HEALTH_EXCLUDE_ROUTES", _DEFAULT_EXCLUDES) or "").split(",")
+    if p.strip()
+)
+
+
+# ---------------- state ----------------
+
+_STARTED_AT = time.time()
+_LOCK = threading.Lock()
+
+# Samples ring: (category, op) -> deque of (ts, ms, ok, store, route, err)
+_SAMPLES: dict[tuple[str, str], deque[tuple[float, float, bool, Optional[str], Optional[str], Optional[str]]]] = {}
+# Per-provider error ring: provider -> deque of (ts, op, err)
+_ERRORS: dict[str, deque[tuple[float, str, str]]] = {}
+# Slow-ops global feed: deque of (ts, category, op, ms, ok, store, route, err)
+_SLOWOPS: deque[tuple[float, str, str, float, bool, Optional[str], Optional[str], Optional[str]]] = deque(maxlen=SLOWOPS_SIZE)
+
+# In-flight tracker: pid -> {kind, started_at, store, label, extra}
+_INFLIGHT: dict[str, dict[str, Any]] = {}
+_INFLIGHT_LOCK = threading.Lock()
+
+# Confirmation stuck-orders probe cache: (ts, result)
+_CONFIRMATION_PROBE: dict[str, Any] = {"ts": 0.0, "result": None, "running": False}
+_CONFIRMATION_PROBE_LOCK = threading.Lock()
+
+# A reference to the SQLAlchemy engine (set by db.py once it's created)
+_DB_ENGINE: Any = None
+
+
+# ---------------- core recording ----------------
+
+def _ring(cat: str, op: str) -> deque:
+    key = (cat, op)
+    d = _SAMPLES.get(key)
+    if d is None:
+        d = deque(maxlen=RING_SIZE)
+        _SAMPLES[key] = d
+    return d
+
+
+def _err_ring(provider: str) -> deque:
+    d = _ERRORS.get(provider)
+    if d is None:
+        d = deque(maxlen=ERR_RING_SIZE)
+        _ERRORS[provider] = d
+    return d
+
+
+def record(category: str, op: str, duration_ms: float, ok: bool, *,
+           store: Optional[str] = None, route: Optional[str] = None,
+           error: Optional[str] = None) -> None:
+    """Record one sample. Cheap; safe to call from any thread."""
+    try:
+        if not category or not op:
+            return
+        now = time.time()
+        ms = float(duration_ms or 0.0)
+        err_short = None
+        if error:
+            es = str(error)
+            err_short = es if len(es) <= 240 else (es[:237] + "...")
+        with _LOCK:
+            _ring(category, op).append((now, ms, bool(ok), store, route, err_short))
+            if not ok and err_short:
+                _err_ring(category).append((now, op, err_short))
+            _SLOWOPS.append((now, category, op, ms, bool(ok), store, route, err_short))
+    except Exception:
+        pass
+
+
+@contextlib.contextmanager
+def time_op(category: str, op: str, *, store: Optional[str] = None, route: Optional[str] = None):
+    """Context manager that times a block and records the sample."""
+    started = time.perf_counter()
+    ok = True
+    err: Optional[str] = None
+    try:
+        yield
+    except BaseException as e:
+        ok = False
+        err = f"{type(e).__name__}: {e}"
+        raise
+    finally:
+        ms = (time.perf_counter() - started) * 1000.0
+        record(category, op, ms, ok, store=store, route=route, error=err)
+
+
+def time_call(category: str, op: str, fn: Callable[..., Any], *args,
+              store: Optional[str] = None, route: Optional[str] = None, **kwargs):
+    """Call ``fn(*args, **kwargs)`` while timing it. Returns the result."""
+    started = time.perf_counter()
+    ok = True
+    err: Optional[str] = None
+    try:
+        return fn(*args, **kwargs)
+    except BaseException as e:
+        ok = False
+        err = f"{type(e).__name__}: {e}"
+        raise
+    finally:
+        ms = (time.perf_counter() - started) * 1000.0
+        record(category, op, ms, ok, store=store, route=route, error=err)
+
+
+# ---------------- in-flight tracker (pipelines, analysis jobs, ad automations) ----------------
+
+def register_inflight(pid: str, kind: str, *, store: Optional[str] = None, label: Optional[str] = None,
+                       extra: Optional[dict] = None) -> None:
+    try:
+        with _INFLIGHT_LOCK:
+            _INFLIGHT[pid] = {
+                "kind": kind,
+                "store": store,
+                "label": label or pid,
+                "started_at": time.time(),
+                "extra": extra or {},
+            }
+    except Exception:
+        pass
+
+
+def clear_inflight(pid: str) -> None:
+    try:
+        with _INFLIGHT_LOCK:
+            _INFLIGHT.pop(pid, None)
+    except Exception:
+        pass
+
+
+def list_inflight() -> list[dict[str, Any]]:
+    try:
+        with _INFLIGHT_LOCK:
+            now = time.time()
+            return [
+                {
+                    "id": pid,
+                    "kind": v.get("kind"),
+                    "store": v.get("store"),
+                    "label": v.get("label"),
+                    "started_at": v.get("started_at"),
+                    "age_s": int(now - float(v.get("started_at") or now)),
+                    "extra": v.get("extra") or {},
+                }
+                for pid, v in _INFLIGHT.items()
+            ]
+    except Exception:
+        return []
+
+
+# ---------------- aggregation ----------------
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    v = sorted(values)
+    k = int(round((p / 100.0) * (len(v) - 1)))
+    return float(v[max(0, min(len(v) - 1, k))])
+
+
+def _summarize(samples: list[tuple], *, window_s: int = WINDOW_S) -> dict[str, Any]:
+    now = time.time()
+    if not samples:
+        return {"count": 0}
+    recent = [s for s in samples if (now - s[0]) <= window_s]
+    if not recent:
+        return {"count": 0}
+    durs = [s[1] for s in recent]
+    ok_count = sum(1 for s in recent if s[2])
+    return {
+        "count": len(recent),
+        "ok": ok_count,
+        "err": len(recent) - ok_count,
+        "err_rate": round((len(recent) - ok_count) / max(1, len(recent)), 4),
+        "p50": int(_percentile(durs, 50)),
+        "p95": int(_percentile(durs, 95)),
+        "p99": int(_percentile(durs, 99)),
+        "max": int(max(durs)),
+        "last_ts": recent[-1][0],
+    }
+
+
+def _summarize_category(category: str, *, window_s: int = WINDOW_S) -> dict[str, Any]:
+    rows: list[tuple] = []
+    with _LOCK:
+        for (cat, _op), d in _SAMPLES.items():
+            if cat == category:
+                rows.extend(d)
+    return _summarize(rows, window_s=window_s)
+
+
+def _by_op(category: str, *, window_s: int = WINDOW_S, limit: int = 20) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with _LOCK:
+        items = [(op, list(d)) for (cat, op), d in _SAMPLES.items() if cat == category]
+    for op, samples in items:
+        s = _summarize(samples, window_s=window_s)
+        if s.get("count"):
+            s["op"] = op
+            out.append(s)
+    # sort: most painful first — err first, then p95
+    out.sort(key=lambda x: (-(x.get("err") or 0), -(x.get("p95") or 0)))
+    return out[:limit]
+
+
+def _recent_errors(category: str, limit: int = 20) -> list[dict[str, Any]]:
+    with _LOCK:
+        d = list(_ERRORS.get(category) or ())
+    d = d[-limit:]
+    return [{"ts": ts, "op": op, "error": err} for (ts, op, err) in reversed(d)]
+
+
+def _slow_ops(limit: int = 50) -> list[dict[str, Any]]:
+    with _LOCK:
+        rows = list(_SLOWOPS)
+    rows.sort(key=lambda x: -x[3])
+    return [
+        {"ts": ts, "category": cat, "op": op, "ms": int(ms), "ok": ok,
+         "store": store, "route": route, "error": err}
+        for (ts, cat, op, ms, ok, store, route, err) in rows[:limit]
+    ]
+
+
+# ---------------- DB / engine ----------------
+
+def attach_db_engine(engine: Any) -> None:
+    """Called by db.py once the SQLAlchemy engine is created."""
+    global _DB_ENGINE
+    _DB_ENGINE = engine
+
+
+def _db_info() -> dict[str, Any]:
+    info: dict[str, Any] = {"driver": None, "url": None, "pool": None, "sqlite_ephemeral_warning": False}
+    try:
+        eng = _DB_ENGINE
+        if eng is None:
+            return info
+        try:
+            info["driver"] = eng.dialect.name  # "sqlite", "postgresql", ...
+        except Exception:
+            pass
+        try:
+            u = str(eng.url)
+            info["url"] = u if not u.startswith("postgresql") else u.split("@")[-1]
+        except Exception:
+            pass
+        try:
+            pool = eng.pool
+            info["pool"] = {
+                "class": type(pool).__name__,
+                "size": getattr(pool, "size", lambda: None)() if callable(getattr(pool, "size", None)) else None,
+                "checked_in": getattr(pool, "checkedin", lambda: None)() if callable(getattr(pool, "checkedin", None)) else None,
+                "checked_out": getattr(pool, "checkedout", lambda: None)() if callable(getattr(pool, "checkedout", None)) else None,
+                "overflow": getattr(pool, "overflow", lambda: None)() if callable(getattr(pool, "overflow", None)) else None,
+            }
+        except Exception:
+            pass
+        try:
+            # Flag the SQLite-on-Cloud-Run footgun
+            if (info.get("driver") or "").lower() == "sqlite":
+                on_cloud_run = bool(os.getenv("K_SERVICE") or os.getenv("CLOUD_RUN_JOB"))
+                info["sqlite_ephemeral_warning"] = on_cloud_run
+        except Exception:
+            pass
+    except Exception:
+        pass
+    return info
+
+
+# ---------------- Celery ----------------
+
+def _celery_info() -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "broker_ok": None,
+        "broker_url": None,
+        "queue_depth": None,
+        "active_workers": None,
+        "last_error": None,
+    }
+    try:
+        from app.config import CELERY_BROKER_URL
+        info["broker_url"] = (CELERY_BROKER_URL or "").split("@")[-1] or None
+        try:
+            from app.tasks import celery as _celery  # type: ignore
+        except Exception as e:
+            info["last_error"] = f"celery_import: {e}"
+            return info
+        try:
+            with _celery.connection_or_acquire() as conn:
+                conn.ensure_connection(max_retries=1, timeout=1.5)
+                info["broker_ok"] = True
+                try:
+                    chan = conn.default_channel
+                    qd = chan.queue_declare(queue="celery", passive=True)
+                    info["queue_depth"] = getattr(qd, "message_count", None)
+                except Exception:
+                    info["queue_depth"] = None
+        except Exception as e:
+            info["broker_ok"] = False
+            info["last_error"] = f"broker: {type(e).__name__}: {e}"
+        try:
+            insp = _celery.control.inspect(timeout=1.0)
+            active = insp.active() or {}
+            info["active_workers"] = sum(len(v or []) for v in active.values())
+        except Exception:
+            info["active_workers"] = None
+    except Exception as e:
+        info["last_error"] = f"{type(e).__name__}: {e}"
+    return info
+
+
+# ---------------- process info ----------------
+
+def _process_info() -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "rss_mb": None,
+        "threads": None,
+        "asyncio_tasks": None,
+        "threadpool_max": None,
+        "pid": os.getpid(),
+    }
+    try:
+        info["threads"] = threading.active_count()
+    except Exception:
+        pass
+    try:
+        import resource  # POSIX-only — guarded
+        ru = resource.getrusage(resource.RUSAGE_SELF)
+        # ru_maxrss is KB on Linux, bytes on macOS
+        kb = ru.ru_maxrss
+        if kb > 10_000_000:  # likely bytes (macOS)
+            info["rss_mb"] = int(kb / (1024 * 1024))
+        else:
+            info["rss_mb"] = int(kb / 1024)
+    except Exception:
+        try:
+            # Fallback for non-POSIX: read /proc/self/statm if available
+            with open("/proc/self/statm", "rb") as fh:
+                fields = fh.read().split()
+                rss_pages = int(fields[1])
+                page_size = os.sysconf("SC_PAGE_SIZE") if hasattr(os, "sysconf") else 4096
+                info["rss_mb"] = int((rss_pages * page_size) / (1024 * 1024))
+        except Exception:
+            pass
+    try:
+        import asyncio
+        loop = asyncio.get_event_loop_policy().get_event_loop()
+        if loop and loop.is_running():
+            info["asyncio_tasks"] = len(asyncio.all_tasks(loop=loop))
+    except Exception:
+        pass
+    try:
+        # Starlette default threadpool is anyio.to_thread.run_sync;
+        # we can read its limiter total_tokens.
+        from anyio.to_thread import current_default_thread_limiter
+        info["threadpool_max"] = int(current_default_thread_limiter().total_tokens)
+    except Exception:
+        pass
+    return info
+
+
+# ---------------- application cache hooks ----------------
+
+# main.py's _API_CACHE / _API_INFLIGHT and the campaign analysis _analysis_jobs
+# dict are module-private. We expose lazy accessors so this module never imports
+# main.py at module load time (avoids circular imports).
+def _app_cache_stats() -> dict[str, Any]:
+    out: dict[str, Any] = {"api_cache_size": None, "api_inflight": None, "analysis_jobs": None}
+    try:
+        import importlib
+        m = importlib.import_module("app.main")
+        c = getattr(m, "_API_CACHE", None)
+        f = getattr(m, "_API_INFLIGHT", None)
+        j = getattr(m, "_analysis_jobs", None)
+        if isinstance(c, dict):
+            out["api_cache_size"] = len(c)
+        if isinstance(f, dict):
+            out["api_inflight"] = len(f)
+        if isinstance(j, dict):
+            out["analysis_jobs"] = len(j)
+    except Exception:
+        pass
+    return out
+
+
+# ---------------- confirmation stuck-orders probe ----------------
+
+def _confirmation_probe_cached() -> Optional[dict[str, Any]]:
+    """Best-effort cached count of open+assigned orders sitting for > CONFIRMATION_STUCK_HOURS.
+
+    Does the heavy Shopify scan in a background thread no more than once per
+    CONFIRMATION_PROBE_TTL_S so the snapshot endpoint stays fast.
+    """
+    now = time.time()
+    with _CONFIRMATION_PROBE_LOCK:
+        ts = float(_CONFIRMATION_PROBE.get("ts") or 0.0)
+        running = bool(_CONFIRMATION_PROBE.get("running"))
+        result = _CONFIRMATION_PROBE.get("result")
+        if (now - ts) > CONFIRMATION_PROBE_TTL_S and not running:
+            _CONFIRMATION_PROBE["running"] = True
+            t = threading.Thread(target=_confirmation_probe_run, daemon=True, name="health-confirmation-probe")
+            t.start()
+    return result
+
+
+def _confirmation_probe_run() -> None:
+    try:
+        stores = [s.strip() for s in (os.getenv("HEALTH_CONFIRMATION_STORES", "irrakids,irranova") or "").split(",") if s.strip()]
+        cutoff_hours = max(1, CONFIRMATION_STUCK_HOURS)
+        from datetime import datetime, timezone, timedelta
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=cutoff_hours)
+        results: dict[str, Any] = {"by_store": {}, "stuck_total": 0, "checked_at": time.time(), "cutoff_hours": cutoff_hours}
+        try:
+            from app.integrations.shopify_client import list_orders_open_unfulfilled
+        except Exception as e:
+            results["error"] = f"shopify_import: {e}"
+            with _CONFIRMATION_PROBE_LOCK:
+                _CONFIRMATION_PROBE["ts"] = time.time()
+                _CONFIRMATION_PROBE["result"] = results
+                _CONFIRMATION_PROBE["running"] = False
+            return
+        try:
+            from app.integrations.shopify_client import has_cod_tag
+        except Exception:
+            has_cod_tag = None  # type: ignore
+
+        def _has_action_tag(tags_str: Any) -> bool:
+            try:
+                if isinstance(tags_str, str):
+                    parts = [t.strip().lower() for t in tags_str.split(",") if t.strip()]
+                elif isinstance(tags_str, list):
+                    parts = [str(t).strip().lower() for t in tags_str if str(t).strip()]
+                else:
+                    return False
+                for t in parts:
+                    if t in ("n1", "n2", "n3", "wtp1", "wtp2", "wtp3"):
+                        return True
+                return False
+            except Exception:
+                return False
+
+        for st in stores:
+            try:
+                stuck = 0
+                total = 0
+                page_info: Optional[str] = None
+                pages = 0
+                while pages < 8:  # safety cap; this is best-effort
+                    res = list_orders_open_unfulfilled(
+                        store=st, limit=250, page_info=page_info,
+                        fields="id,tags,created_at,assigned_location_id",
+                    )
+                    orders = (res or {}).get("orders") or []
+                    for o in orders:
+                        if not isinstance(o, dict):
+                            continue
+                        total += 1
+                        try:
+                            if has_cod_tag and has_cod_tag(o.get("tags")):
+                                continue
+                        except Exception:
+                            pass
+                        if _has_action_tag(o.get("tags")):
+                            continue
+                        try:
+                            created = o.get("created_at")
+                            if not created:
+                                continue
+                            dt = datetime.fromisoformat(str(created).replace("Z", "+00:00"))
+                            if dt < cutoff:
+                                stuck += 1
+                        except Exception:
+                            continue
+                    page_info = (res or {}).get("next_page_info") or None
+                    pages += 1
+                    if not page_info:
+                        break
+                results["by_store"][st] = {"stuck": stuck, "scanned": total, "pages": pages, "truncated": bool(page_info)}
+                results["stuck_total"] += stuck
+            except Exception as e:
+                results["by_store"][st] = {"error": f"{type(e).__name__}: {e}"}
+        with _CONFIRMATION_PROBE_LOCK:
+            _CONFIRMATION_PROBE["ts"] = time.time()
+            _CONFIRMATION_PROBE["result"] = results
+            _CONFIRMATION_PROBE["running"] = False
+    except Exception as e:
+        try:
+            _log.warning("confirmation_probe_failed: %s", e)
+        except Exception:
+            pass
+        with _CONFIRMATION_PROBE_LOCK:
+            _CONFIRMATION_PROBE["ts"] = time.time()
+            _CONFIRMATION_PROBE["result"] = {"error": f"{type(e).__name__}: {e}", "checked_at": time.time()}
+            _CONFIRMATION_PROBE["running"] = False
+
+
+# ---------------- snapshot + status ----------------
+
+PROVIDERS = ("shopify", "meta", "openai", "openai_image", "gemini", "clarity")
+
+
+def snapshot() -> dict[str, Any]:
+    """Full JSON snapshot for the admin dashboard."""
+    now = time.time()
+    # Per-surface request summary
+    request_by_surface: dict[str, dict[str, Any]] = {}
+    request_by_op: list[dict[str, Any]] = []
+    with _LOCK:
+        for (cat, op), d in _SAMPLES.items():
+            if cat == "request":
+                rows = [r for r in d if (now - r[0]) <= WINDOW_S]
+                if not rows:
+                    continue
+                surface = (rows[-1][4] or op).split(":", 1)[0]
+                bucket = request_by_surface.setdefault(surface, [])
+                bucket.extend(rows)
+    surface_summary: dict[str, dict[str, Any]] = {
+        s: _summarize(rows) for s, rows in request_by_surface.items() if rows
+    }
+    # By-op for requests (top painful)
+    request_by_op = _by_op("request", limit=25)
+
+    providers: dict[str, Any] = {}
+    for p in PROVIDERS:
+        providers[p] = {
+            "summary": _summarize_category(p),
+            "by_op": _by_op(p, limit=15),
+            "recent_errors": _recent_errors(p, limit=15),
+        }
+
+    db_summary = _summarize_category("db")
+    db_by_op = _by_op("db", limit=15)
+    db_info = _db_info()
+
+    out: dict[str, Any] = {
+        "now": now,
+        "started_at": _STARTED_AT,
+        "uptime_s": int(now - _STARTED_AT),
+        "config": {
+            "window_s": WINDOW_S,
+            "ring_size": RING_SIZE,
+            "thresholds_ms": THRESHOLDS_MS,
+            "err_rate_warn": ERR_RATE_WARN,
+            "err_rate_crit": ERR_RATE_CRIT,
+            "inflight_warn": INFLIGHT_WARN,
+            "inflight_crit": INFLIGHT_CRIT,
+            "pipeline_stale_s": PIPELINE_STALE_S,
+            "confirmation_stuck_hours": CONFIRMATION_STUCK_HOURS,
+            "confirmation_probe_ttl_s": CONFIRMATION_PROBE_TTL_S,
+        },
+        "deployment": {
+            "cloud_run_service": os.getenv("K_SERVICE") or None,
+            "cloud_run_revision": os.getenv("K_REVISION") or None,
+            "instance_id": os.getenv("K_REVISION") or os.getenv("HOSTNAME") or None,
+            "use_celery_env": (os.getenv("USE_CELERY", "false") or "").lower() in ("1", "true", "yes"),
+        },
+        "request": {
+            "summary": _summarize_category("request"),
+            "by_surface": surface_summary,
+            "by_op": request_by_op,
+        },
+        "providers": providers,
+        "db": {"summary": db_summary, "by_op": db_by_op, **db_info},
+        "cache": _app_cache_stats(),
+        "celery": _celery_info(),
+        "process": _process_info(),
+        "pipelines": {
+            "inflight": list_inflight(),
+            "count": len(_INFLIGHT),
+        },
+        "confirmation": _confirmation_probe_cached() or {"pending": True},
+        "slow_ops": _slow_ops(limit=50),
+    }
+    return out
+
+
+def status() -> dict[str, Any]:
+    """At-a-glance status. Returns {level, reasons[]} where each reason is
+    {level, code, msg, value?, threshold?}.
+    """
+    snap = snapshot()
+    reasons: list[dict[str, Any]] = []
+
+    def _add(level: str, code: str, msg: str, **extra: Any) -> None:
+        item = {"level": level, "code": code, "msg": msg}
+        item.update(extra)
+        reasons.append(item)
+
+    # 1) DB checks
+    db = snap.get("db") or {}
+    if db.get("sqlite_ephemeral_warning"):
+        _add("crit", "DB_SQLITE_ON_CLOUD_RUN",
+             "Backend is using SQLite on Cloud Run (ephemeral disk). Data will be lost on instance recycle.")
+    db_sum = db.get("summary") or {}
+    if (db_sum.get("count") or 0) >= MIN_SAMPLES:
+        warn, crit = THRESHOLDS_MS["db"]
+        p95 = db_sum.get("p95") or 0
+        if p95 >= crit:
+            _add("crit", "DB_P95", f"DB p95 {p95}ms ≥ {crit}ms", value=p95, threshold=crit)
+        elif p95 >= warn:
+            _add("warn", "DB_P95", f"DB p95 {p95}ms ≥ {warn}ms", value=p95, threshold=warn)
+
+    # 2) Provider checks
+    for p, data in (snap.get("providers") or {}).items():
+        s = (data or {}).get("summary") or {}
+        if (s.get("count") or 0) < MIN_SAMPLES:
+            continue
+        warn, crit = THRESHOLDS_MS.get(p, (None, None))
+        p95 = s.get("p95") or 0
+        if warn and crit:
+            if p95 >= crit:
+                _add("crit", f"{p.upper()}_P95",
+                     f"{p} p95 {p95}ms ≥ {crit}ms (n={s.get('count')})",
+                     value=p95, threshold=crit, provider=p)
+            elif p95 >= warn:
+                _add("warn", f"{p.upper()}_P95",
+                     f"{p} p95 {p95}ms ≥ {warn}ms (n={s.get('count')})",
+                     value=p95, threshold=warn, provider=p)
+        err_rate = float(s.get("err_rate") or 0.0)
+        if err_rate >= ERR_RATE_CRIT:
+            _add("crit", f"{p.upper()}_ERR_RATE",
+                 f"{p} error rate {err_rate:.1%} ≥ {ERR_RATE_CRIT:.0%} (n={s.get('count')})",
+                 value=err_rate, threshold=ERR_RATE_CRIT, provider=p)
+        elif err_rate >= ERR_RATE_WARN:
+            _add("warn", f"{p.upper()}_ERR_RATE",
+                 f"{p} error rate {err_rate:.1%} ≥ {ERR_RATE_WARN:.0%} (n={s.get('count')})",
+                 value=err_rate, threshold=ERR_RATE_WARN, provider=p)
+
+    # 3) Request-latency checks (overall)
+    req = (snap.get("request") or {}).get("summary") or {}
+    if (req.get("count") or 0) >= MIN_SAMPLES:
+        warn, crit = THRESHOLDS_MS["request"]
+        p95 = req.get("p95") or 0
+        if p95 >= crit:
+            _add("crit", "REQ_P95", f"Request p95 {p95}ms ≥ {crit}ms", value=p95, threshold=crit)
+        elif p95 >= warn:
+            _add("warn", "REQ_P95", f"Request p95 {p95}ms ≥ {warn}ms", value=p95, threshold=warn)
+
+    # 3b) Per-surface request checks — surface-specific slowness
+    for surface, s in (snap.get("request") or {}).get("by_surface", {}).items():
+        if (s.get("count") or 0) < MIN_SAMPLES:
+            continue
+        warn, crit = THRESHOLDS_MS["request"]
+        p95 = s.get("p95") or 0
+        if p95 >= crit:
+            _add("warn", "REQ_SURFACE_P95",
+                 f"Surface '{surface}' p95 {p95}ms ≥ {crit}ms", value=p95, threshold=crit, surface=surface)
+
+    # 4) Celery / pipelines
+    cel = snap.get("celery") or {}
+    if cel.get("broker_ok") is False:
+        _add("crit", "CELERY_BROKER_DOWN",
+             f"Celery broker unreachable: {cel.get('last_error') or 'unknown'}")
+    qd = cel.get("queue_depth")
+    if isinstance(qd, int):
+        if qd >= CELERY_QUEUE_CRIT:
+            _add("crit", "CELERY_QUEUE",
+                 f"Celery queue depth {qd} ≥ {CELERY_QUEUE_CRIT}", value=qd, threshold=CELERY_QUEUE_CRIT)
+        elif qd >= CELERY_QUEUE_WARN:
+            _add("warn", "CELERY_QUEUE",
+                 f"Celery queue depth {qd} ≥ {CELERY_QUEUE_WARN}", value=qd, threshold=CELERY_QUEUE_WARN)
+
+    pipes = snap.get("pipelines") or {}
+    in_n = int(pipes.get("count") or 0)
+    if in_n >= INFLIGHT_CRIT:
+        _add("crit", "PIPELINES_INFLIGHT",
+             f"{in_n} in-flight background jobs ≥ {INFLIGHT_CRIT}", value=in_n)
+    elif in_n >= INFLIGHT_WARN:
+        _add("warn", "PIPELINES_INFLIGHT",
+             f"{in_n} in-flight background jobs ≥ {INFLIGHT_WARN}", value=in_n)
+    # stuck pipelines
+    stale = [p for p in (pipes.get("inflight") or []) if (p.get("age_s") or 0) >= PIPELINE_STALE_S]
+    if stale:
+        _add("warn", "PIPELINES_STUCK",
+             f"{len(stale)} background job(s) older than {PIPELINE_STALE_S}s — possibly stuck",
+             ids=[p.get("id") for p in stale][:10])
+
+    # 5) Confirmation SLA
+    conf = snap.get("confirmation") or {}
+    stuck = conf.get("stuck_total")
+    if isinstance(stuck, int):
+        if stuck >= CONFIRMATION_STUCK_CRIT:
+            _add("crit", "CONFIRMATION_STUCK",
+                 f"{stuck} open orders without action > {CONFIRMATION_STUCK_HOURS}h",
+                 value=stuck, threshold=CONFIRMATION_STUCK_CRIT)
+        elif stuck >= CONFIRMATION_STUCK_WARN:
+            _add("warn", "CONFIRMATION_STUCK",
+                 f"{stuck} open orders without action > {CONFIRMATION_STUCK_HOURS}h",
+                 value=stuck, threshold=CONFIRMATION_STUCK_WARN)
+
+    # 6) Memory pressure
+    proc = snap.get("process") or {}
+    rss = proc.get("rss_mb")
+    if isinstance(rss, int):
+        if rss >= RSS_CRIT_MB:
+            _add("crit", "MEMORY", f"RSS {rss}MB ≥ {RSS_CRIT_MB}MB", value=rss, threshold=RSS_CRIT_MB)
+        elif rss >= RSS_WARN_MB:
+            _add("warn", "MEMORY", f"RSS {rss}MB ≥ {RSS_WARN_MB}MB", value=rss, threshold=RSS_WARN_MB)
+
+    # Overall level
+    level = "ok"
+    if any(r["level"] == "crit" for r in reasons):
+        level = "crit"
+    elif any(r["level"] == "warn" for r in reasons):
+        level = "warn"
+
+    return {
+        "level": level,
+        "reasons": reasons,
+        "uptime_s": snap.get("uptime_s"),
+        "now": snap.get("now"),
+    }
+
+
+# ---------------- ASGI middleware ----------------
+
+# Surface tagging: route prefix -> surface label. Order matters (most specific first).
+SURFACE_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("/api/ads-management",     "ads_management"),
+    ("/api/confirmation/admin", "confirmation_admin"),
+    ("/api/confirmation",       "confirmation"),
+    ("/api/page-builder",       "page_builder"),
+    ("/api/theme-editor",       "theme_editor"),
+    ("/api/wholesale",          "wholesale"),
+    ("/api/profit_campaign",    "profit"),
+    ("/api/profit_cards",       "profit"),
+    ("/api/profit_costs",       "profit"),
+    ("/api/profit_calculator",  "profit"),
+    ("/api/campaign",           "campaign_analyzer"),
+    ("/api/agent",              "agent"),
+    ("/api/agentbuilder",       "agent"),
+    ("/api/agents",             "agent"),
+    ("/api/llm",                "llm"),
+    ("/api/gemini",             "gemini_api"),
+    ("/api/clarity",            "clarity_api"),
+    ("/api/chatkit",            "chatkit"),
+    ("/api/meta",               "meta_api"),
+    ("/api/shopify",            "shopify_api"),
+    ("/api/flows",              "flows"),
+    ("/api/tests",              "tests"),
+    ("/api/translate",          "llm"),
+    ("/api/uploads",            "uploads"),
+    ("/api/prompts",            "prompts"),
+    ("/api/page-builder",       "page_builder"),
+    ("/api/exchange",           "exchange"),
+    ("/api/campaign_mappings",  "campaign_meta"),
+    ("/api/campaign_meta",      "campaign_meta"),
+    ("/api/system-health",      "system_health"),
+)
+
+
+def _classify_surface(path: str) -> str:
+    for prefix, label in SURFACE_PATTERNS:
+        if path.startswith(prefix):
+            return label
+    return "other"
+
+
+def _is_excluded(path: str) -> bool:
+    for p in EXCLUDE_ROUTES:
+        if path.startswith(p):
+            return True
+    return False
+
+
+class HealthMiddleware:
+    """Pure ASGI middleware; records request latency per (surface, route)."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path") or ""
+        if _is_excluded(path):
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method") or "GET"
+        surface = _classify_surface(path)
+        op = f"{method} {path}"
+        started = time.perf_counter()
+        status_code_holder: dict[str, int] = {}
+        ok = True
+        err: Optional[str] = None
+
+        async def _send(message):
+            try:
+                if message.get("type") == "http.response.start":
+                    status_code_holder["status"] = int(message.get("status") or 0)
+            except Exception:
+                pass
+            await send(message)
+
+        try:
+            await self.app(scope, receive, _send)
+        except BaseException as e:
+            ok = False
+            err = f"{type(e).__name__}: {e}"
+            raise
+        finally:
+            try:
+                sc = status_code_holder.get("status") or 0
+                if sc >= 500:
+                    ok = False
+                ms = (time.perf_counter() - started) * 1000.0
+                # route is "surface:METHOD path" so the surface bucket can extract it
+                record("request", op, ms, ok, route=f"{surface}:{op}", error=err)
+            except Exception:
+                pass

--- a/backend/app/system_health_routes.py
+++ b/backend/app/system_health_routes.py
@@ -1,0 +1,201 @@
+"""Admin-gated routes for the System Health dashboard.
+
+Auth model:
+  - Bearer token issued by POST /api/system-health/login.
+  - Credentials come from the SYSTEM_ADMIN_USERS env var (JSON map or array,
+    same shape as CONFIRMATION_ADMIN_USERS). Signing secret is
+    SYSTEM_ADMIN_SECRET, falling back to JWT_SECRET.
+  - Tokens carry role="sys_admin" and an exp claim; verified via HMAC-SHA256.
+
+Routes (all under /api/system-health):
+  POST /login                      -> { token, admin: { email, name? } }
+  GET  /me                         -> { admin } | 401
+  GET  /snapshot                   -> full JSON snapshot
+  GET  /status                     -> { level, reasons[] }
+  POST /confirmation-probe/refresh -> kick the confirmation stuck-orders probe
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from app import system_health as sh
+
+
+router = APIRouter(prefix="/api/system-health", tags=["system-health"])
+
+
+# ---------------- auth helpers ----------------
+
+def _b64u_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64u_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode((s or "") + pad)
+
+
+def _secret() -> bytes:
+    sec = (
+        os.getenv("SYSTEM_ADMIN_SECRET", "")
+        or os.getenv("JWT_SECRET", "")
+        or ""
+    ).strip()
+    if not sec:
+        sec = "dev-system-admin-secret"
+    return sec.encode("utf-8")
+
+
+def _issue_token(payload: dict) -> str:
+    msg = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    body = _b64u_encode(msg)
+    sig = _b64u_encode(hmac.new(_secret(), body.encode("ascii"), hashlib.sha256).digest())
+    return f"{body}.{sig}"
+
+
+def _verify_token(token: str) -> Optional[dict]:
+    try:
+        tok = (token or "").strip()
+        if not tok or "." not in tok:
+            return None
+        body, sig = tok.split(".", 1)
+        exp_sig = _b64u_encode(hmac.new(_secret(), body.encode("ascii"), hashlib.sha256).digest())
+        if not hmac.compare_digest(exp_sig, sig):
+            return None
+        payload = json.loads(_b64u_decode(body).decode("utf-8"))
+        if not isinstance(payload, dict):
+            return None
+        if (payload.get("role") or "").lower() != "sys_admin":
+            return None
+        try:
+            exp = int(payload.get("exp") or 0)
+            if exp and int(time.time()) > exp:
+                return None
+        except Exception:
+            return None
+        return payload
+    except Exception:
+        return None
+
+
+def _load_admin_users() -> list[dict]:
+    out: list[dict] = []
+    try:
+        raw = (os.getenv("SYSTEM_ADMIN_USERS", "") or "").strip()
+        if not raw:
+            return out
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            for u in parsed:
+                if isinstance(u, dict) and u.get("email") and u.get("password"):
+                    out.append({
+                        "email": str(u["email"]).strip().lower(),
+                        "password": str(u["password"]),
+                        "name": u.get("name"),
+                    })
+        elif isinstance(parsed, dict):
+            for k, v in parsed.items():
+                if k and v:
+                    out.append({
+                        "email": str(k).strip().lower(),
+                        "password": str(v),
+                        "name": None,
+                    })
+    except Exception:
+        return out
+    return out
+
+
+def _get_admin(req: Request) -> Optional[dict]:
+    auth = (req.headers.get("authorization") or req.headers.get("Authorization") or "").strip()
+    token = ""
+    if auth.lower().startswith("bearer "):
+        token = auth.split(" ", 1)[1].strip()
+    if not token:
+        token = (req.headers.get("x-system-admin-token") or "").strip()
+    if not token:
+        return None
+    return _verify_token(token)
+
+
+# ---------------- routes ----------------
+
+class LoginBody(BaseModel):
+    email: str
+    password: str
+    remember: Optional[bool] = True
+
+
+@router.post("/login")
+async def login(body: LoginBody):
+    users = _load_admin_users()
+    if not users:
+        return {"error": "no_admins_configured", "hint": "Set SYSTEM_ADMIN_USERS env"}
+    email = (body.email or "").strip().lower()
+    pw = body.password or ""
+    found = None
+    for u in users:
+        if u.get("email") == email and hmac.compare_digest(str(u.get("password") or ""), pw):
+            found = u
+            break
+    if not found:
+        return {"error": "invalid_credentials"}
+    now = int(time.time())
+    ttl = 7 * 24 * 3600 if body.remember else 8 * 3600
+    token = _issue_token({"sub": email, "name": found.get("name"), "role": "sys_admin", "iat": now, "exp": now + ttl})
+    return {"data": {"token": token, "admin": {"email": email, "name": found.get("name")}}}
+
+
+@router.get("/me")
+async def me(req: Request):
+    admin = _get_admin(req)
+    if not admin:
+        return {"error": "unauthorized"}
+    return {"data": {"admin": {"email": admin.get("sub"), "name": admin.get("name")}}}
+
+
+@router.get("/snapshot")
+async def get_snapshot(req: Request):
+    admin = _get_admin(req)
+    if not admin:
+        return {"error": "unauthorized"}
+    try:
+        return {"data": sh.snapshot()}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}
+
+
+@router.get("/status")
+async def get_status(req: Request):
+    admin = _get_admin(req)
+    if not admin:
+        return {"error": "unauthorized"}
+    try:
+        return {"data": sh.status()}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}", "data": {"level": "warn", "reasons": [{"level": "warn", "code": "HEALTH_INTERNAL", "msg": f"snapshot failed: {e}"}]}}
+
+
+@router.post("/confirmation-probe/refresh")
+async def refresh_confirmation_probe(req: Request):
+    admin = _get_admin(req)
+    if not admin:
+        return {"error": "unauthorized"}
+    try:
+        # Force a refresh by zeroing the cache ts
+        with sh._CONFIRMATION_PROBE_LOCK:  # noqa: SLF001
+            sh._CONFIRMATION_PROBE["ts"] = 0.0  # noqa: SLF001
+        result = sh._confirmation_probe_cached()  # noqa: SLF001
+        return {"data": result or {"pending": True}}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -115,5 +115,16 @@ def run_pipeline_sync(test_id: str, payload: dict):
 
 @celery.task(name="pipeline_launch")
 def pipeline_launch(test_id: str, payload: dict):
-    # Delegate to the shared sync implementation so both paths stay identical
-    return run_pipeline_sync(test_id, payload)
+    # Delegate to the shared sync implementation so both paths stay identical.
+    # Also register the run in system_health so the worker's in-flight pipelines
+    # show up if/when USE_CELERY=true and the worker shares process with the API.
+    try:
+        from app import system_health as _sh
+        _sh.register_inflight(f"pipeline:{test_id}", "pipeline", store=(payload or {}).get("store"), label=f"test {test_id}")
+        try:
+            with _sh.time_op("pipeline", "celery.pipeline_launch", store=(payload or {}).get("store")):
+                return run_pipeline_sync(test_id, payload)
+        finally:
+            _sh.clear_inflight(f"pipeline:{test_id}")
+    except Exception:
+        return run_pipeline_sync(test_id, payload)

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -96,6 +96,9 @@ export default function HomePage(){
           <Link href="/wholesale" className="rounded-xl font-semibold inline-flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white">
             Wholesale
           </Link>
+          <Link href="/system-health" className="rounded-xl font-semibold inline-flex items-center gap-2 px-4 py-2 bg-slate-700 hover:bg-slate-800 text-white">
+            System Health
+          </Link>
           <button onClick={()=>setShowNew(true)} className="rounded-xl font-semibold inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white">
             <Plus className="w-4 h-4"/> New flow
           </button>

--- a/frontend/app/system-health/page.tsx
+++ b/frontend/app/system-health/page.tsx
@@ -1,0 +1,473 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  systemHealthLogin,
+  systemHealthSnapshot,
+  systemHealthStatus,
+  systemHealthRefreshConfirmation,
+} from "@/lib/api"
+
+type Level = "ok" | "warn" | "crit"
+
+type StatusResp = {
+  level: Level
+  reasons: Array<{ level: Level; code: string; msg: string; value?: any; threshold?: any; provider?: string; surface?: string; ids?: string[] }>
+  uptime_s?: number
+  now?: number
+}
+
+function levelColor(l: Level): string {
+  if (l === "crit") return "bg-red-600 text-white"
+  if (l === "warn") return "bg-amber-500 text-white"
+  return "bg-emerald-600 text-white"
+}
+function levelText(l: Level): string {
+  return l.toUpperCase()
+}
+function fmtMs(n?: number | null): string {
+  if (n == null) return "—"
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}s`
+  return `${Math.round(n)}ms`
+}
+function fmtPct(n?: number | null): string {
+  if (n == null || isNaN(Number(n))) return "—"
+  return `${(Number(n) * 100).toFixed(1)}%`
+}
+function fmtTime(ts?: number | null): string {
+  if (!ts) return "—"
+  try { return new Date(ts * 1000).toLocaleTimeString() } catch { return "—" }
+}
+function fmtDuration(s?: number | null): string {
+  if (s == null) return "—"
+  if (s < 60) return `${Math.round(s)}s`
+  if (s < 3600) return `${Math.round(s / 60)}m`
+  return `${Math.round(s / 3600)}h${Math.round((s % 3600) / 60)}m`
+}
+
+function Card({ title, right, children, tone = "default" as "default" | "ok" | "warn" | "crit" }: { title: string; right?: React.ReactNode; children: React.ReactNode; tone?: "default" | "ok" | "warn" | "crit" }) {
+  const ring = tone === "crit" ? "ring-2 ring-red-300" : tone === "warn" ? "ring-2 ring-amber-300" : ""
+  return (
+    <div className={`bg-white border rounded-2xl shadow-sm ${ring}`}>
+      <div className="px-4 pt-4 pb-2 flex items-center justify-between">
+        <div className="font-semibold text-sm">{title}</div>
+        <div>{right}</div>
+      </div>
+      <div className="px-4 pb-4">{children}</div>
+    </div>
+  )
+}
+
+function SummaryStats({ s }: { s: any }) {
+  if (!s || !s.count) return <div className="text-xs text-slate-400">no samples yet</div>
+  return (
+    <div className="grid grid-cols-4 gap-2 text-xs">
+      <Stat label="p50" value={fmtMs(s.p50)} />
+      <Stat label="p95" value={fmtMs(s.p95)} />
+      <Stat label="p99" value={fmtMs(s.p99)} />
+      <Stat label="max" value={fmtMs(s.max)} />
+      <Stat label="n" value={String(s.count)} />
+      <Stat label="ok" value={String(s.ok)} />
+      <Stat label="err" value={String(s.err)} className={s.err > 0 ? "text-red-600 font-semibold" : ""} />
+      <Stat label="err%" value={fmtPct(s.err_rate)} className={s.err_rate > 0.1 ? "text-red-600 font-semibold" : s.err_rate > 0 ? "text-amber-700" : ""} />
+    </div>
+  )
+}
+
+function Stat({ label, value, className = "" }: { label: string; value: string; className?: string }) {
+  return (
+    <div className="bg-slate-50 rounded px-2 py-1 border">
+      <div className="text-[10px] uppercase text-slate-500">{label}</div>
+      <div className={`text-sm tabular-nums ${className}`}>{value}</div>
+    </div>
+  )
+}
+
+function OpTable({ rows, opCol = "op" }: { rows: any[]; opCol?: string }) {
+  if (!rows || rows.length === 0) return <div className="text-xs text-slate-400">no samples yet</div>
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs tabular-nums">
+        <thead className="text-left text-slate-500">
+          <tr>
+            <th className="py-1 pr-2 font-normal">{opCol}</th>
+            <th className="py-1 px-1 font-normal text-right">n</th>
+            <th className="py-1 px-1 font-normal text-right">p50</th>
+            <th className="py-1 px-1 font-normal text-right">p95</th>
+            <th className="py-1 px-1 font-normal text-right">p99</th>
+            <th className="py-1 px-1 font-normal text-right">max</th>
+            <th className="py-1 px-1 font-normal text-right">err%</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 12).map((r, i) => (
+            <tr key={i} className="border-t">
+              <td className="py-1 pr-2 truncate max-w-[260px]" title={r.op || ""}>{r.op || "—"}</td>
+              <td className="py-1 px-1 text-right">{r.count}</td>
+              <td className="py-1 px-1 text-right">{fmtMs(r.p50)}</td>
+              <td className="py-1 px-1 text-right">{fmtMs(r.p95)}</td>
+              <td className="py-1 px-1 text-right">{fmtMs(r.p99)}</td>
+              <td className="py-1 px-1 text-right">{fmtMs(r.max)}</td>
+              <td className={`py-1 px-1 text-right ${r.err_rate > 0.1 ? "text-red-600 font-semibold" : r.err_rate > 0 ? "text-amber-700" : "text-slate-500"}`}>{fmtPct(r.err_rate)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ErrorList({ rows }: { rows: Array<{ ts: number; op: string; error: string }> }) {
+  if (!rows || rows.length === 0) return <div className="text-xs text-slate-400">no recent errors</div>
+  return (
+    <div className="space-y-1 max-h-[180px] overflow-y-auto">
+      {rows.map((r, i) => (
+        <div key={i} className="text-xs border-l-2 border-red-300 pl-2">
+          <div className="text-slate-500">{fmtTime(r.ts)} <span className="text-slate-400">·</span> {r.op}</div>
+          <div className="text-red-700 truncate" title={r.error}>{r.error}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function SystemHealthPage() {
+  const [authed, setAuthed] = useState(false)
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [loginErr, setLoginErr] = useState<string | null>(null)
+  const [status, setStatus] = useState<StatusResp | null>(null)
+  const [snap, setSnap] = useState<any | null>(null)
+  const [snapErr, setSnapErr] = useState<string | null>(null)
+  const [lastFetched, setLastFetched] = useState<number | null>(null)
+  const [paused, setPaused] = useState(false)
+  const pollRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    try {
+      const tok = localStorage.getItem("ptos_system_admin_token") || ""
+      if (tok) setAuthed(true)
+    } catch {}
+  }, [])
+
+  const doLogin = useCallback(async () => {
+    setLoginErr(null)
+    try {
+      const res = await systemHealthLogin({ email, password, remember: true })
+      if (res?.error) { setLoginErr(res.error + (res.hint ? ` — ${res.hint}` : "")); return }
+      const tok = res?.data?.token
+      if (!tok) { setLoginErr("missing_token"); return }
+      try { localStorage.setItem("ptos_system_admin_token", tok) } catch {}
+      setAuthed(true)
+    } catch (e: any) {
+      setLoginErr(String(e?.response?.data?.error || e?.message || e))
+    }
+  }, [email, password])
+
+  const doLogout = useCallback(() => {
+    try { localStorage.removeItem("ptos_system_admin_token") } catch {}
+    setAuthed(false); setStatus(null); setSnap(null)
+  }, [])
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [st, sn] = await Promise.all([systemHealthStatus(), systemHealthSnapshot()])
+      if (st?.error === "unauthorized" || sn?.error === "unauthorized") { doLogout(); return }
+      if (st?.data) setStatus(st.data)
+      if (sn?.data) { setSnap(sn.data); setSnapErr(null) }
+      if (sn?.error) setSnapErr(String(sn.error))
+      setLastFetched(Date.now())
+    } catch (e: any) {
+      setSnapErr(String(e?.response?.data?.error || e?.message || e))
+    }
+  }, [doLogout])
+
+  useEffect(() => {
+    if (!authed) return
+    fetchAll()
+    if (paused) return
+    pollRef.current = window.setInterval(fetchAll, 5000) as unknown as number
+    return () => { if (pollRef.current) { window.clearInterval(pollRef.current); pollRef.current = null } }
+  }, [authed, paused, fetchAll])
+
+  const overallTone: Level = status?.level || "ok"
+
+  if (!authed) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-50">
+        <div className="bg-white border rounded-2xl shadow p-6 w-[92vw] max-w-md">
+          <h1 className="text-lg font-semibold mb-1">System Health</h1>
+          <p className="text-xs text-slate-500 mb-4">Admin-only. Credentials come from <code>SYSTEM_ADMIN_USERS</code>.</p>
+          <form onSubmit={(e) => { e.preventDefault(); doLogin() }} className="space-y-3">
+            <input className="w-full border rounded-lg px-3 py-2 text-sm" placeholder="admin@example.com" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="username" />
+            <input className="w-full border rounded-lg px-3 py-2 text-sm" placeholder="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="current-password" />
+            <button className="w-full rounded-lg bg-slate-900 text-white py-2 text-sm font-semibold hover:bg-black">Sign in</button>
+            {loginErr && <div className="text-xs text-red-600">{loginErr}</div>}
+          </form>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="h-16 px-4 md:px-6 flex items-center justify-between border-b bg-white sticky top-0 z-10">
+        <div className="flex items-center gap-3">
+          <div className={`px-3 py-1 rounded-full text-xs font-bold ${levelColor(overallTone)}`}>{levelText(overallTone)}</div>
+          <h1 className="font-semibold">System Health</h1>
+          {snap && (
+            <span className="text-xs text-slate-500">
+              uptime {fmtDuration(snap.uptime_s)} · revision {snap.deployment?.cloud_run_revision || "local"} · {snap.deployment?.use_celery_env ? "celery" : "threads"}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {lastFetched && <span className="text-xs text-slate-500">last fetch {new Date(lastFetched).toLocaleTimeString()}</span>}
+          <button onClick={() => setPaused((p) => !p)} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50">{paused ? "Resume" : "Pause"} polling</button>
+          <button onClick={fetchAll} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50">Refresh now</button>
+          <button onClick={doLogout} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50">Sign out</button>
+        </div>
+      </header>
+
+      <div className="p-4 md:p-6 space-y-4">
+        {/* Headline card: reasons */}
+        <Card title={`Overall — ${status?.level?.toUpperCase() || "OK"}`} tone={overallTone}>
+          {status && status.reasons.length === 0 ? (
+            <div className="text-sm text-emerald-700">All checks pass. {snap?.request?.summary?.count ? `(${snap.request.summary.count} requests in last ${Math.round((snap.config?.window_s || 600) / 60)}m)` : ""}</div>
+          ) : (
+            <ul className="space-y-1 text-sm">
+              {status?.reasons?.map((r, i) => (
+                <li key={i} className="flex items-start gap-2">
+                  <span className={`mt-0.5 inline-block px-1.5 py-0.5 rounded text-[10px] font-bold ${levelColor(r.level)}`}>{r.level.toUpperCase()}</span>
+                  <span>
+                    <span className="font-mono text-xs text-slate-500">{r.code}</span> — {r.msg}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {snapErr && <div className="mt-2 text-xs text-red-600">snapshot error: {snapErr}</div>}
+        </Card>
+
+        {/* Top row: deployment + cache + process */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Card title="Deployment">
+            {snap ? (
+              <div className="text-xs space-y-1">
+                <div><span className="text-slate-500">service</span> {snap.deployment?.cloud_run_service || "local"}</div>
+                <div><span className="text-slate-500">revision</span> {snap.deployment?.cloud_run_revision || "—"}</div>
+                <div><span className="text-slate-500">instance</span> {snap.deployment?.instance_id || "—"}</div>
+                <div><span className="text-slate-500">pipeline mode</span> {snap.deployment?.use_celery_env ? "celery" : "threads (sync)"}</div>
+                <div><span className="text-slate-500">db driver</span> {snap.db?.driver || "—"}{snap.db?.sqlite_ephemeral_warning && <span className="ml-1 px-1.5 rounded bg-red-600 text-white">SQLite on Cloud Run</span>}</div>
+              </div>
+            ) : <div className="text-xs text-slate-400">loading…</div>}
+          </Card>
+
+          <Card title="Process">
+            {snap?.process ? (
+              <div className="grid grid-cols-2 gap-2 text-xs">
+                <Stat label="RSS MB" value={String(snap.process.rss_mb ?? "—")} />
+                <Stat label="threads" value={String(snap.process.threads ?? "—")} />
+                <Stat label="asyncio tasks" value={String(snap.process.asyncio_tasks ?? "—")} />
+                <Stat label="threadpool max" value={String(snap.process.threadpool_max ?? "—")} />
+              </div>
+            ) : <div className="text-xs text-slate-400">loading…</div>}
+          </Card>
+
+          <Card title="In-process caches">
+            {snap?.cache ? (
+              <div className="grid grid-cols-3 gap-2 text-xs">
+                <Stat label="API cache" value={String(snap.cache.api_cache_size ?? "—")} />
+                <Stat label="inflight futures" value={String(snap.cache.api_inflight ?? "—")} />
+                <Stat label="analysis jobs" value={String(snap.cache.analysis_jobs ?? "—")} />
+              </div>
+            ) : <div className="text-xs text-slate-400">loading…</div>}
+          </Card>
+        </div>
+
+        {/* Pipelines + Celery + Confirmation SLA */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Card title={`Background jobs (${snap?.pipelines?.count ?? 0})`}>
+            <div className="text-xs space-y-2">
+              {!snap?.pipelines?.inflight?.length && <div className="text-slate-400">none running</div>}
+              {snap?.pipelines?.inflight?.map((p: any) => {
+                const stale = (p.age_s ?? 0) >= (snap.config?.pipeline_stale_s ?? 1800)
+                return (
+                  <div key={p.id} className={`border rounded p-2 ${stale ? "border-red-300 bg-red-50" : ""}`}>
+                    <div className="font-mono text-[10px] text-slate-500">{p.kind}</div>
+                    <div className="truncate">{p.label}</div>
+                    <div className="text-slate-500">age {fmtDuration(p.age_s)}{p.store ? ` · ${p.store}` : ""}</div>
+                  </div>
+                )
+              })}
+            </div>
+          </Card>
+
+          <Card title="Celery worker">
+            {snap?.celery ? (
+              <div className="text-xs space-y-1">
+                <div>
+                  broker:{" "}
+                  <span className={snap.celery.broker_ok === true ? "text-emerald-700" : snap.celery.broker_ok === false ? "text-red-600 font-semibold" : "text-slate-500"}>
+                    {snap.celery.broker_ok === true ? "ok" : snap.celery.broker_ok === false ? "down" : "?"}
+                  </span>
+                </div>
+                <div className="text-slate-500 truncate">{snap.celery.broker_url || "—"}</div>
+                <div>queue depth: <span className="tabular-nums">{snap.celery.queue_depth ?? "—"}</span></div>
+                <div>active workers: <span className="tabular-nums">{snap.celery.active_workers ?? "—"}</span></div>
+                {snap.celery.last_error && <div className="text-red-600 truncate" title={snap.celery.last_error}>{snap.celery.last_error}</div>}
+              </div>
+            ) : <div className="text-xs text-slate-400">loading…</div>}
+          </Card>
+
+          <Card title="Confirmation SLA">
+            {snap?.confirmation ? (
+              <div className="text-xs space-y-1">
+                {snap.confirmation.pending ? (
+                  <div className="text-slate-500">first scan in progress…</div>
+                ) : snap.confirmation.error ? (
+                  <div className="text-red-600 truncate" title={snap.confirmation.error}>{snap.confirmation.error}</div>
+                ) : (
+                  <>
+                    <div className="text-2xl font-bold tabular-nums">{snap.confirmation.stuck_total ?? 0}</div>
+                    <div className="text-slate-500">open + assigned orders without n/wtp action older than {snap.confirmation.cutoff_hours}h</div>
+                    {snap.confirmation.by_store && (
+                      <div className="space-y-0.5 mt-2">
+                        {Object.entries(snap.confirmation.by_store).map(([store, v]: any) => (
+                          <div key={store} className="font-mono">{store}: {v.error ? <span className="text-red-600">{v.error}</span> : <>stuck {v.stuck} / scanned {v.scanned}{v.truncated ? " (truncated)" : ""}</>}</div>
+                        ))}
+                      </div>
+                    )}
+                    <div className="text-slate-400">checked {fmtTime(snap.confirmation.checked_at)}</div>
+                  </>
+                )}
+                <button onClick={() => systemHealthRefreshConfirmation().then(fetchAll)} className="mt-1 text-[11px] rounded border px-2 py-0.5 hover:bg-slate-50">Force refresh</button>
+              </div>
+            ) : <div className="text-xs text-slate-400">loading…</div>}
+          </Card>
+        </div>
+
+        {/* Providers */}
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {snap && ["shopify", "meta", "openai", "openai_image", "gemini", "clarity"].map((p) => {
+            const data = snap.providers?.[p]
+            if (!data) return null
+            return (
+              <Card key={p} title={`${p}`}>
+                <SummaryStats s={data.summary} />
+                <div className="mt-3 border-t pt-2">
+                  <div className="text-[10px] uppercase text-slate-500 mb-1">slowest / failing ops</div>
+                  <OpTable rows={data.by_op} />
+                </div>
+                <div className="mt-3 border-t pt-2">
+                  <div className="text-[10px] uppercase text-slate-500 mb-1">recent errors</div>
+                  <ErrorList rows={data.recent_errors} />
+                </div>
+              </Card>
+            )
+          })}
+        </div>
+
+        {/* DB */}
+        <Card title={`Database — ${snap?.db?.driver || "?"}`}>
+          {snap?.db?.sqlite_ephemeral_warning && (
+            <div className="mb-2 text-xs px-2 py-1 rounded bg-red-50 text-red-700 border border-red-200">
+              You are running SQLite on Cloud Run. The /app/data directory is ephemeral; data will not survive instance recycles. Set <code>DATABASE_URL</code> to a managed Postgres.
+            </div>
+          )}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div>
+              <div className="text-[10px] uppercase text-slate-500 mb-1">overall</div>
+              <SummaryStats s={snap?.db?.summary} />
+              {snap?.db?.pool && (
+                <div className="mt-2 text-xs space-y-0.5">
+                  <div><span className="text-slate-500">pool class</span> {snap.db.pool.class}</div>
+                  <div><span className="text-slate-500">size</span> {snap.db.pool.size ?? "—"} <span className="text-slate-500 ml-2">checked out</span> {snap.db.pool.checked_out ?? "—"} <span className="text-slate-500 ml-2">overflow</span> {snap.db.pool.overflow ?? "—"}</div>
+                </div>
+              )}
+            </div>
+            <div className="md:col-span-2">
+              <div className="text-[10px] uppercase text-slate-500 mb-1">slowest / failing ops</div>
+              <OpTable rows={snap?.db?.by_op} />
+            </div>
+          </div>
+        </Card>
+
+        {/* Requests per surface */}
+        <Card title="Requests by surface">
+          {snap?.request?.by_surface && Object.keys(snap.request.by_surface).length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs tabular-nums">
+                <thead className="text-left text-slate-500">
+                  <tr>
+                    <th className="py-1 pr-2 font-normal">surface</th>
+                    <th className="py-1 px-1 font-normal text-right">n</th>
+                    <th className="py-1 px-1 font-normal text-right">p50</th>
+                    <th className="py-1 px-1 font-normal text-right">p95</th>
+                    <th className="py-1 px-1 font-normal text-right">p99</th>
+                    <th className="py-1 px-1 font-normal text-right">max</th>
+                    <th className="py-1 px-1 font-normal text-right">err%</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {Object.entries(snap.request.by_surface).map(([surface, s]: any) => (
+                    <tr key={surface} className="border-t">
+                      <td className="py-1 pr-2 font-mono">{surface}</td>
+                      <td className="py-1 px-1 text-right">{s.count}</td>
+                      <td className="py-1 px-1 text-right">{fmtMs(s.p50)}</td>
+                      <td className="py-1 px-1 text-right">{fmtMs(s.p95)}</td>
+                      <td className="py-1 px-1 text-right">{fmtMs(s.p99)}</td>
+                      <td className="py-1 px-1 text-right">{fmtMs(s.max)}</td>
+                      <td className={`py-1 px-1 text-right ${s.err_rate > 0.1 ? "text-red-600 font-semibold" : s.err_rate > 0 ? "text-amber-700" : "text-slate-500"}`}>{fmtPct(s.err_rate)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : <div className="text-xs text-slate-400">no requests sampled yet</div>}
+        </Card>
+
+        {/* Slowest individual routes */}
+        <Card title="Slowest / failing routes">
+          <OpTable rows={snap?.request?.by_op} opCol="route" />
+        </Card>
+
+        {/* Global slow-ops feed */}
+        <Card title="Slow ops feed (top 50, sorted by duration)">
+          {snap?.slow_ops?.length ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs tabular-nums">
+                <thead className="text-left text-slate-500">
+                  <tr>
+                    <th className="py-1 pr-2 font-normal">time</th>
+                    <th className="py-1 px-1 font-normal">category</th>
+                    <th className="py-1 px-1 font-normal">op</th>
+                    <th className="py-1 px-1 font-normal text-right">ms</th>
+                    <th className="py-1 px-1 font-normal">store</th>
+                    <th className="py-1 px-1 font-normal">error</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snap.slow_ops.map((r: any, i: number) => (
+                    <tr key={i} className={`border-t ${!r.ok ? "bg-red-50" : ""}`}>
+                      <td className="py-1 pr-2 text-slate-500">{fmtTime(r.ts)}</td>
+                      <td className="py-1 px-1 font-mono">{r.category}</td>
+                      <td className="py-1 px-1 truncate max-w-[260px]" title={r.op}>{r.op}</td>
+                      <td className="py-1 px-1 text-right">{fmtMs(r.ms)}</td>
+                      <td className="py-1 px-1">{r.store || ""}</td>
+                      <td className="py-1 px-1 text-red-600 truncate max-w-[280px]" title={r.error || ""}>{r.error || ""}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : <div className="text-xs text-slate-400">no samples yet</div>}
+        </Card>
+
+        <div className="text-[10px] text-slate-400 pb-6">
+          window: last {Math.round((snap?.config?.window_s || 600) / 60)} min · ring size {snap?.config?.ring_size} · in-memory only (resets on instance recycle)
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1369,3 +1369,38 @@ export async function getLatestBulkAnalysis(store?: string): Promise<{ data?: Bu
   return data as { data?: BulkAnalysisJob | null, error?: string }
 }
 
+
+// -------- System Health (admin-only) --------
+function systemAdminToken(){
+  try{ return typeof window!=='undefined' ? (localStorage.getItem('ptos_system_admin_token')||'') : '' }catch{ return '' }
+}
+function systemAdminHeaders(){
+  const tok = systemAdminToken()
+  return tok? { Authorization: `Bearer ${tok}` } : {}
+}
+
+export async function systemHealthLogin(payload:{ email: string, password: string, remember?: boolean }){
+  const { data } = await axios.post(`${base}/api/system-health/login`, payload)
+  return data as { data?: { token: string, admin: { email: string, name?: string|null } }, error?: string, hint?: string }
+}
+
+export async function systemHealthMe(){
+  const { data } = await axios.get(`${base}/api/system-health/me`, { headers: { ...systemAdminHeaders() } })
+  return data as { data?: { admin: { email: string, name?: string|null } }, error?: string }
+}
+
+export async function systemHealthSnapshot(){
+  const { data } = await axios.get(`${base}/api/system-health/snapshot`, { headers: { ...systemAdminHeaders() } })
+  return data as { data?: any, error?: string }
+}
+
+export async function systemHealthStatus(){
+  const { data } = await axios.get(`${base}/api/system-health/status`, { headers: { ...systemAdminHeaders() } })
+  return data as { data?: { level: 'ok'|'warn'|'crit', reasons: Array<{ level:'ok'|'warn'|'crit', code:string, msg:string, value?:any, threshold?:any, provider?:string, surface?:string }>, uptime_s?: number, now?: number }, error?: string }
+}
+
+export async function systemHealthRefreshConfirmation(){
+  const { data } = await axios.post(`${base}/api/system-health/confirmation-probe/refresh`, {}, { headers: { ...systemAdminHeaders() } })
+  return data as { data?: any, error?: string }
+}
+


### PR DESCRIPTION
In-memory, bounded, additive-only telemetry covering every dashboard and feature in the app: per-surface request latency, per-provider outbound HTTP (Shopify/Meta/OpenAI/Gemini/Clarity), DB query timings + pool stats, in-flight background pipelines (previously invisible because they run as bare threads), Celery broker health, and a Confirmation-team SLA card for open+assigned orders sitting past N hours without action.

Exposes /api/system-health/{login,me,snapshot,status,confirmation-probe/refresh} gated by SYSTEM_ADMIN_USERS / SYSTEM_ADMIN_SECRET (separate from confirmation admin). Frontend /system-health polls every 5s with an honest ok/warn/crit badge and a list of specific reasons. All thresholds are env-tunable; see the docstring at the top of backend/app/system_health.py.

No new dependencies, no DB schema changes, no edits to business logic. Instrumentation hooks live at the integration-helper level so a bug in the metrics path cannot break a request.