### PR TITLE
Fix System Health text contrast and add persistent incident log

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -105,6 +105,13 @@ from app.system_health_routes import router as _system_health_router  # noqa: E4
 from app import system_health as _sh  # noqa: E402
 app.add_middleware(_HealthMiddleware)
 app.include_router(_system_health_router)
+# Background poller keeps the incident log up to date even when nobody is
+# watching the dashboard, so issues that occurred while the admin was away
+# are still visible (with first/last-seen timestamps) when they return.
+try:
+    _sh._ensure_incident_poller()  # noqa: SLF001
+except Exception:
+    pass
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/system_health.py
+++ b/backend/app/system_health.py
@@ -71,6 +71,12 @@ Auth
   SYSTEM_ADMIN_USERS              (JSON map or array — see system_health_routes.py)
   SYSTEM_ADMIN_SECRET             (signing secret for tokens; falls back to JWT_SECRET)
 
+Incident log
+  HEALTH_INCIDENT_LOG_SIZE         (200)   max past incidents kept in memory
+  HEALTH_INCIDENT_POLLER_S         (60)    background poller cadence — keeps the log
+                                           up to date even when no client is polling
+                                           the dashboard. Set to 0 to disable.
+
 Misc
   HEALTH_EXCLUDE_ROUTES           (comma-sep prefixes excluded from request timing;
                                    default: /uploads,/health,/api/system-health,/favicon.ico)
@@ -145,6 +151,9 @@ CONFIRMATION_PROBE_TTL_S = _int_env("HEALTH_CONFIRMATION_PROBE_TTL_S", 300)
 RSS_WARN_MB = _int_env("HEALTH_RSS_WARN_MB", 350)
 RSS_CRIT_MB = _int_env("HEALTH_RSS_CRIT_MB", 480)
 
+INCIDENT_LOG_SIZE = _int_env("HEALTH_INCIDENT_LOG_SIZE", 200)
+INCIDENT_POLLER_S = _int_env("HEALTH_INCIDENT_POLLER_S", 60)
+
 _DEFAULT_EXCLUDES = "/uploads,/health,/api/system-health,/favicon.ico"
 EXCLUDE_ROUTES: tuple[str, ...] = tuple(
     p.strip() for p in (os.getenv("HEALTH_EXCLUDE_ROUTES", _DEFAULT_EXCLUDES) or "").split(",")
@@ -171,6 +180,17 @@ _INFLIGHT_LOCK = threading.Lock()
 # Confirmation stuck-orders probe cache: (ts, result)
 _CONFIRMATION_PROBE: dict[str, Any] = {"ts": 0.0, "result": None, "running": False}
 _CONFIRMATION_PROBE_LOCK = threading.Lock()
+
+# Incident log: persists past warn/crit reasons with first_seen / last_seen / resolved_at.
+# Keyed by code so flapping doesn't spam the log; the same code re-opening after
+# resolution starts a new incident entry.
+_INCIDENTS_LOCK = threading.Lock()
+_INCIDENTS: deque[dict[str, Any]] = deque(maxlen=INCIDENT_LOG_SIZE)
+_OPEN_INCIDENTS: dict[str, int] = {}  # code -> index into _INCIDENTS (when still open)
+
+# Background poller state
+_POLLER_STARTED = False
+_POLLER_LOCK = threading.Lock()
 
 # A reference to the SQLAlchemy engine (set by db.py once it's created)
 _DB_ENGINE: Any = None
@@ -718,8 +738,108 @@ def snapshot() -> dict[str, Any]:
         },
         "confirmation": _confirmation_probe_cached() or {"pending": True},
         "slow_ops": _slow_ops(limit=50),
+        "incidents": list_incidents(limit=100),
     }
     return out
+
+
+def _record_incidents(reasons: list[dict[str, Any]]) -> None:
+    """Maintain the rolling incident log.
+
+    - New reason whose code is not in ``_OPEN_INCIDENTS`` → append a new
+      incident entry (first_seen = last_seen = now).
+    - Reason whose code IS open → update last_seen + level + msg + tick count.
+    - Open incident whose code is absent from current reasons → mark resolved.
+    """
+    try:
+        now = time.time()
+        current_codes = {r.get("code"): r for r in reasons or [] if isinstance(r, dict) and r.get("code")}
+        with _INCIDENTS_LOCK:
+            # Index incidents by id for stable references
+            incidents_list = list(_INCIDENTS)
+
+            # 1) Update / open
+            for code, r in current_codes.items():
+                if code in _OPEN_INCIDENTS:
+                    idx = _OPEN_INCIDENTS[code]
+                    # The deque might have evicted the entry if it was very old;
+                    # fall back to re-opening in that case.
+                    try:
+                        entry = incidents_list[idx]
+                    except Exception:
+                        entry = None
+                    if entry is not None and entry.get("code") == code and not entry.get("resolved_at"):
+                        entry["last_seen"] = now
+                        entry["level"] = r.get("level") or entry.get("level")
+                        entry["msg"] = r.get("msg") or entry.get("msg")
+                        entry["tick_count"] = int(entry.get("tick_count") or 0) + 1
+                        # propagate optional extras
+                        for k in ("value", "threshold", "provider", "surface", "ids"):
+                            if k in r:
+                                entry[k] = r[k]
+                        continue
+                    # Stale index — fall through to open a new one
+                    _OPEN_INCIDENTS.pop(code, None)
+                # New incident
+                entry = {
+                    "id": f"{int(now * 1000)}-{code}",
+                    "code": code,
+                    "level": r.get("level"),
+                    "msg": r.get("msg"),
+                    "first_seen": now,
+                    "last_seen": now,
+                    "resolved_at": None,
+                    "tick_count": 1,
+                }
+                for k in ("value", "threshold", "provider", "surface", "ids"):
+                    if k in r:
+                        entry[k] = r[k]
+                _INCIDENTS.append(entry)
+                # Recompute open index map (deque can evict on append)
+                incidents_list = list(_INCIDENTS)
+                _OPEN_INCIDENTS[code] = len(incidents_list) - 1
+
+            # 2) Resolve incidents whose codes are no longer active
+            still_open: dict[str, int] = {}
+            for code, idx in list(_OPEN_INCIDENTS.items()):
+                try:
+                    entry = incidents_list[idx]
+                except Exception:
+                    continue
+                if entry.get("code") != code:
+                    continue
+                if code in current_codes:
+                    still_open[code] = idx
+                else:
+                    if not entry.get("resolved_at"):
+                        entry["resolved_at"] = now
+            _OPEN_INCIDENTS.clear()
+            _OPEN_INCIDENTS.update(still_open)
+    except Exception:
+        pass
+
+
+def list_incidents(limit: int = 100) -> list[dict[str, Any]]:
+    """Return incidents newest-first. Open incidents have resolved_at=None."""
+    try:
+        with _INCIDENTS_LOCK:
+            items = list(_INCIDENTS)
+        # Newest first; open incidents first within same time
+        items.sort(key=lambda e: (e.get("resolved_at") is not None, -float(e.get("last_seen") or 0)))
+        return items[:limit]
+    except Exception:
+        return []
+
+
+def clear_incidents() -> int:
+    try:
+        with _INCIDENTS_LOCK:
+            n = len(_INCIDENTS)
+            _INCIDENTS.clear()
+            _OPEN_INCIDENTS.clear()
+            return n
+    except Exception:
+        return 0
 
 
 def status() -> dict[str, Any]:
@@ -852,12 +972,43 @@ def status() -> dict[str, Any]:
     elif any(r["level"] == "warn" for r in reasons):
         level = "warn"
 
+    # Update the incident log so past issues remain visible even when resolved
+    _record_incidents(reasons)
+
     return {
         "level": level,
         "reasons": reasons,
         "uptime_s": snap.get("uptime_s"),
         "now": snap.get("now"),
     }
+
+
+def _ensure_incident_poller() -> None:
+    """Spin up a daemon thread that calls status() every HEALTH_INCIDENT_POLLER_S
+    so the incident log accumulates issues even when no client is polling.
+
+    Safe to call repeatedly; only starts once.
+    """
+    global _POLLER_STARTED
+    if INCIDENT_POLLER_S <= 0:
+        return
+    with _POLLER_LOCK:
+        if _POLLER_STARTED:
+            return
+        _POLLER_STARTED = True
+
+    def _poll():
+        # Small initial delay so app start-up isn't slowed by an immediate scan
+        time.sleep(min(15, INCIDENT_POLLER_S))
+        while True:
+            try:
+                status()
+            except Exception:
+                pass
+            time.sleep(max(5, INCIDENT_POLLER_S))
+
+    t = threading.Thread(target=_poll, daemon=True, name="health-incident-poller")
+    t.start()
 
 
 # ---------------- ASGI middleware ----------------

--- a/backend/app/system_health_routes.py
+++ b/backend/app/system_health_routes.py
@@ -186,6 +186,18 @@ async def get_status(req: Request):
         return {"error": f"{type(e).__name__}: {e}", "data": {"level": "warn", "reasons": [{"level": "warn", "code": "HEALTH_INTERNAL", "msg": f"snapshot failed: {e}"}]}}
 
 
+@router.post("/incidents/clear")
+async def clear_incidents(req: Request):
+    admin = _get_admin(req)
+    if not admin:
+        return {"error": "unauthorized"}
+    try:
+        n = sh.clear_incidents()
+        return {"data": {"cleared": n}}
+    except Exception as e:
+        return {"error": f"{type(e).__name__}: {e}"}
+
+
 @router.post("/confirmation-probe/refresh")
 async def refresh_confirmation_probe(req: Request):
     admin = _get_admin(req)

--- a/frontend/app/system-health/page.tsx
+++ b/frontend/app/system-health/page.tsx
@@ -6,6 +6,7 @@ import {
   systemHealthSnapshot,
   systemHealthStatus,
   systemHealthRefreshConfirmation,
+  systemHealthClearIncidents,
 } from "@/lib/api"
 
 type Level = "ok" | "warn" | "crit"
@@ -44,22 +45,31 @@ function fmtDuration(s?: number | null): string {
   if (s < 3600) return `${Math.round(s / 60)}m`
   return `${Math.round(s / 3600)}h${Math.round((s % 3600) / 60)}m`
 }
+function fmtDateTime(ts?: number | null): string {
+  if (!ts) return "—"
+  try {
+    const d = new Date(ts * 1000)
+    return d.toLocaleString(undefined, { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit", second: "2-digit" })
+  } catch {
+    return "—"
+  }
+}
 
 function Card({ title, right, children, tone = "default" as "default" | "ok" | "warn" | "crit" }: { title: string; right?: React.ReactNode; children: React.ReactNode; tone?: "default" | "ok" | "warn" | "crit" }) {
   const ring = tone === "crit" ? "ring-2 ring-red-300" : tone === "warn" ? "ring-2 ring-amber-300" : ""
   return (
-    <div className={`bg-white border rounded-2xl shadow-sm ${ring}`}>
+    <div className={`bg-white border rounded-2xl shadow-sm text-slate-800 ${ring}`}>
       <div className="px-4 pt-4 pb-2 flex items-center justify-between">
-        <div className="font-semibold text-sm">{title}</div>
+        <div className="font-semibold text-sm text-slate-900">{title}</div>
         <div>{right}</div>
       </div>
-      <div className="px-4 pb-4">{children}</div>
+      <div className="px-4 pb-4 text-slate-800">{children}</div>
     </div>
   )
 }
 
 function SummaryStats({ s }: { s: any }) {
-  if (!s || !s.count) return <div className="text-xs text-slate-400">no samples yet</div>
+  if (!s || !s.count) return <div className="text-xs text-slate-500">no samples yet</div>
   return (
     <div className="grid grid-cols-4 gap-2 text-xs">
       <Stat label="p50" value={fmtMs(s.p50)} />
@@ -68,8 +78,8 @@ function SummaryStats({ s }: { s: any }) {
       <Stat label="max" value={fmtMs(s.max)} />
       <Stat label="n" value={String(s.count)} />
       <Stat label="ok" value={String(s.ok)} />
-      <Stat label="err" value={String(s.err)} className={s.err > 0 ? "text-red-600 font-semibold" : ""} />
-      <Stat label="err%" value={fmtPct(s.err_rate)} className={s.err_rate > 0.1 ? "text-red-600 font-semibold" : s.err_rate > 0 ? "text-amber-700" : ""} />
+      <Stat label="err" value={String(s.err)} className={s.err > 0 ? "text-red-600 font-semibold" : "text-slate-800"} />
+      <Stat label="err%" value={fmtPct(s.err_rate)} className={s.err_rate > 0.1 ? "text-red-600 font-semibold" : s.err_rate > 0 ? "text-amber-700" : "text-slate-800"} />
     </div>
   )
 }
@@ -78,16 +88,16 @@ function Stat({ label, value, className = "" }: { label: string; value: string; 
   return (
     <div className="bg-slate-50 rounded px-2 py-1 border">
       <div className="text-[10px] uppercase text-slate-500">{label}</div>
-      <div className={`text-sm tabular-nums ${className}`}>{value}</div>
+      <div className={`text-sm tabular-nums text-slate-900 ${className}`}>{value}</div>
     </div>
   )
 }
 
 function OpTable({ rows, opCol = "op" }: { rows: any[]; opCol?: string }) {
-  if (!rows || rows.length === 0) return <div className="text-xs text-slate-400">no samples yet</div>
+  if (!rows || rows.length === 0) return <div className="text-xs text-slate-500">no samples yet</div>
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-xs tabular-nums">
+      <table className="w-full text-xs tabular-nums text-slate-800">
         <thead className="text-left text-slate-500">
           <tr>
             <th className="py-1 pr-2 font-normal">{opCol}</th>
@@ -102,7 +112,7 @@ function OpTable({ rows, opCol = "op" }: { rows: any[]; opCol?: string }) {
         <tbody>
           {rows.slice(0, 12).map((r, i) => (
             <tr key={i} className="border-t">
-              <td className="py-1 pr-2 truncate max-w-[260px]" title={r.op || ""}>{r.op || "—"}</td>
+              <td className="py-1 pr-2 truncate max-w-[260px] text-slate-800" title={r.op || ""}>{r.op || "—"}</td>
               <td className="py-1 px-1 text-right">{r.count}</td>
               <td className="py-1 px-1 text-right">{fmtMs(r.p50)}</td>
               <td className="py-1 px-1 text-right">{fmtMs(r.p95)}</td>
@@ -118,15 +128,74 @@ function OpTable({ rows, opCol = "op" }: { rows: any[]; opCol?: string }) {
 }
 
 function ErrorList({ rows }: { rows: Array<{ ts: number; op: string; error: string }> }) {
-  if (!rows || rows.length === 0) return <div className="text-xs text-slate-400">no recent errors</div>
+  if (!rows || rows.length === 0) return <div className="text-xs text-slate-500">no recent errors</div>
   return (
     <div className="space-y-1 max-h-[180px] overflow-y-auto">
       {rows.map((r, i) => (
         <div key={i} className="text-xs border-l-2 border-red-300 pl-2">
-          <div className="text-slate-500">{fmtTime(r.ts)} <span className="text-slate-400">·</span> {r.op}</div>
+          <div className="text-slate-500">{fmtTime(r.ts)} <span className="text-slate-400">·</span> <span className="text-slate-700">{r.op}</span></div>
           <div className="text-red-700 truncate" title={r.error}>{r.error}</div>
         </div>
       ))}
+    </div>
+  )
+}
+
+function IncidentLog({ incidents, onClear }: { incidents: any[]; onClear: () => void }) {
+  if (!incidents || incidents.length === 0) {
+    return <div className="text-xs text-slate-500">no incidents recorded yet</div>
+  }
+  const open = incidents.filter((i) => !i.resolved_at)
+  const resolved = incidents.filter((i) => i.resolved_at)
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between text-xs">
+        <div className="text-slate-600">
+          <span className="font-semibold text-slate-900">{open.length}</span> open ·{" "}
+          <span className="font-semibold text-slate-900">{resolved.length}</span> resolved
+        </div>
+        <button onClick={onClear} className="text-[11px] rounded border px-2 py-0.5 hover:bg-slate-50 text-slate-700">
+          Clear history
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs text-slate-800">
+          <thead className="text-left text-slate-500">
+            <tr>
+              <th className="py-1 pr-2 font-normal">status</th>
+              <th className="py-1 pr-2 font-normal">level</th>
+              <th className="py-1 pr-2 font-normal">code</th>
+              <th className="py-1 pr-2 font-normal">message</th>
+              <th className="py-1 pr-2 font-normal">first seen</th>
+              <th className="py-1 pr-2 font-normal">last seen</th>
+              <th className="py-1 pr-2 font-normal">resolved</th>
+              <th className="py-1 pr-2 font-normal text-right">ticks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {incidents.slice(0, 50).map((e: any) => (
+              <tr key={e.id} className={`border-t ${!e.resolved_at ? (e.level === "crit" ? "bg-red-50" : "bg-amber-50") : ""}`}>
+                <td className="py-1 pr-2">
+                  {e.resolved_at ? (
+                    <span className="px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-800 text-[10px] font-semibold">RESOLVED</span>
+                  ) : (
+                    <span className="px-1.5 py-0.5 rounded bg-red-600 text-white text-[10px] font-semibold">OPEN</span>
+                  )}
+                </td>
+                <td className="py-1 pr-2">
+                  <span className={`px-1.5 py-0.5 rounded text-[10px] font-bold ${levelColor(e.level)}`}>{e.level?.toUpperCase()}</span>
+                </td>
+                <td className="py-1 pr-2 font-mono text-[11px] text-slate-700">{e.code}</td>
+                <td className="py-1 pr-2 text-slate-800 truncate max-w-[420px]" title={e.msg}>{e.msg}</td>
+                <td className="py-1 pr-2 text-slate-600 tabular-nums">{fmtDateTime(e.first_seen)}</td>
+                <td className="py-1 pr-2 text-slate-600 tabular-nums">{fmtDateTime(e.last_seen)}</td>
+                <td className="py-1 pr-2 text-slate-600 tabular-nums">{e.resolved_at ? fmtDateTime(e.resolved_at) : "—"}</td>
+                <td className="py-1 pr-2 text-right tabular-nums text-slate-700">{e.tick_count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   )
 }
@@ -194,13 +263,13 @@ export default function SystemHealthPage() {
 
   if (!authed) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-slate-50">
-        <div className="bg-white border rounded-2xl shadow p-6 w-[92vw] max-w-md">
-          <h1 className="text-lg font-semibold mb-1">System Health</h1>
-          <p className="text-xs text-slate-500 mb-4">Admin-only. Credentials come from <code>SYSTEM_ADMIN_USERS</code>.</p>
+      <div className="min-h-screen flex items-center justify-center bg-slate-50 text-slate-800">
+        <div className="bg-white border rounded-2xl shadow p-6 w-[92vw] max-w-md text-slate-800">
+          <h1 className="text-lg font-semibold mb-1 text-slate-900">System Health</h1>
+          <p className="text-xs text-slate-600 mb-4">Admin-only. Credentials come from <code className="text-slate-800">SYSTEM_ADMIN_USERS</code>.</p>
           <form onSubmit={(e) => { e.preventDefault(); doLogin() }} className="space-y-3">
-            <input className="w-full border rounded-lg px-3 py-2 text-sm" placeholder="admin@example.com" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="username" />
-            <input className="w-full border rounded-lg px-3 py-2 text-sm" placeholder="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="current-password" />
+            <input className="w-full border rounded-lg px-3 py-2 text-sm text-slate-900 bg-white" placeholder="admin@example.com" value={email} onChange={(e) => setEmail(e.target.value)} autoComplete="username" />
+            <input className="w-full border rounded-lg px-3 py-2 text-sm text-slate-900 bg-white" placeholder="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} autoComplete="current-password" />
             <button className="w-full rounded-lg bg-slate-900 text-white py-2 text-sm font-semibold hover:bg-black">Sign in</button>
             {loginErr && <div className="text-xs text-red-600">{loginErr}</div>}
           </form>
@@ -210,36 +279,36 @@ export default function SystemHealthPage() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      <header className="h-16 px-4 md:px-6 flex items-center justify-between border-b bg-white sticky top-0 z-10">
+    <div className="min-h-screen bg-slate-50 text-slate-800">
+      <header className="h-16 px-4 md:px-6 flex items-center justify-between border-b bg-white sticky top-0 z-10 text-slate-800">
         <div className="flex items-center gap-3">
           <div className={`px-3 py-1 rounded-full text-xs font-bold ${levelColor(overallTone)}`}>{levelText(overallTone)}</div>
-          <h1 className="font-semibold">System Health</h1>
+          <h1 className="font-semibold text-slate-900">System Health</h1>
           {snap && (
-            <span className="text-xs text-slate-500">
+            <span className="text-xs text-slate-600">
               uptime {fmtDuration(snap.uptime_s)} · revision {snap.deployment?.cloud_run_revision || "local"} · {snap.deployment?.use_celery_env ? "celery" : "threads"}
             </span>
           )}
         </div>
         <div className="flex items-center gap-2">
-          {lastFetched && <span className="text-xs text-slate-500">last fetch {new Date(lastFetched).toLocaleTimeString()}</span>}
-          <button onClick={() => setPaused((p) => !p)} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50">{paused ? "Resume" : "Pause"} polling</button>
-          <button onClick={fetchAll} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50">Refresh now</button>
-          <button onClick={doLogout} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50">Sign out</button>
+          {lastFetched && <span className="text-xs text-slate-600">last fetch {new Date(lastFetched).toLocaleTimeString()}</span>}
+          <button onClick={() => setPaused((p) => !p)} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50 text-slate-800">{paused ? "Resume" : "Pause"} polling</button>
+          <button onClick={fetchAll} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50 text-slate-800">Refresh now</button>
+          <button onClick={doLogout} className="text-xs rounded border px-2 py-1 bg-white hover:bg-slate-50 text-slate-800">Sign out</button>
         </div>
       </header>
 
-      <div className="p-4 md:p-6 space-y-4">
+      <div className="p-4 md:p-6 space-y-4 text-slate-800">
         {/* Headline card: reasons */}
         <Card title={`Overall — ${status?.level?.toUpperCase() || "OK"}`} tone={overallTone}>
           {status && status.reasons.length === 0 ? (
             <div className="text-sm text-emerald-700">All checks pass. {snap?.request?.summary?.count ? `(${snap.request.summary.count} requests in last ${Math.round((snap.config?.window_s || 600) / 60)}m)` : ""}</div>
           ) : (
-            <ul className="space-y-1 text-sm">
+            <ul className="space-y-1 text-sm text-slate-800">
               {status?.reasons?.map((r, i) => (
                 <li key={i} className="flex items-start gap-2">
                   <span className={`mt-0.5 inline-block px-1.5 py-0.5 rounded text-[10px] font-bold ${levelColor(r.level)}`}>{r.level.toUpperCase()}</span>
-                  <span>
+                  <span className="text-slate-800">
                     <span className="font-mono text-xs text-slate-500">{r.code}</span> — {r.msg}
                   </span>
                 </li>
@@ -249,18 +318,26 @@ export default function SystemHealthPage() {
           {snapErr && <div className="mt-2 text-xs text-red-600">snapshot error: {snapErr}</div>}
         </Card>
 
+        {/* Incident log — persistent record of past + current issues with timestamps */}
+        <Card title="Incident log (past 200 issues)">
+          <IncidentLog
+            incidents={snap?.incidents || []}
+            onClear={() => systemHealthClearIncidents().then(fetchAll)}
+          />
+        </Card>
+
         {/* Top row: deployment + cache + process */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card title="Deployment">
             {snap ? (
-              <div className="text-xs space-y-1">
-                <div><span className="text-slate-500">service</span> {snap.deployment?.cloud_run_service || "local"}</div>
-                <div><span className="text-slate-500">revision</span> {snap.deployment?.cloud_run_revision || "—"}</div>
-                <div><span className="text-slate-500">instance</span> {snap.deployment?.instance_id || "—"}</div>
-                <div><span className="text-slate-500">pipeline mode</span> {snap.deployment?.use_celery_env ? "celery" : "threads (sync)"}</div>
-                <div><span className="text-slate-500">db driver</span> {snap.db?.driver || "—"}{snap.db?.sqlite_ephemeral_warning && <span className="ml-1 px-1.5 rounded bg-red-600 text-white">SQLite on Cloud Run</span>}</div>
+              <div className="text-xs space-y-1 text-slate-800">
+                <div><span className="text-slate-500">service</span> <span className="text-slate-900">{snap.deployment?.cloud_run_service || "local"}</span></div>
+                <div><span className="text-slate-500">revision</span> <span className="text-slate-900">{snap.deployment?.cloud_run_revision || "—"}</span></div>
+                <div><span className="text-slate-500">instance</span> <span className="text-slate-900">{snap.deployment?.instance_id || "—"}</span></div>
+                <div><span className="text-slate-500">pipeline mode</span> <span className="text-slate-900">{snap.deployment?.use_celery_env ? "celery" : "threads (sync)"}</span></div>
+                <div><span className="text-slate-500">db driver</span> <span className="text-slate-900">{snap.db?.driver || "—"}</span>{snap.db?.sqlite_ephemeral_warning && <span className="ml-1 px-1.5 rounded bg-red-600 text-white">SQLite on Cloud Run</span>}</div>
               </div>
-            ) : <div className="text-xs text-slate-400">loading…</div>}
+            ) : <div className="text-xs text-slate-500">loading…</div>}
           </Card>
 
           <Card title="Process">
@@ -271,7 +348,7 @@ export default function SystemHealthPage() {
                 <Stat label="asyncio tasks" value={String(snap.process.asyncio_tasks ?? "—")} />
                 <Stat label="threadpool max" value={String(snap.process.threadpool_max ?? "—")} />
               </div>
-            ) : <div className="text-xs text-slate-400">loading…</div>}
+            ) : <div className="text-xs text-slate-500">loading…</div>}
           </Card>
 
           <Card title="In-process caches">
@@ -281,22 +358,22 @@ export default function SystemHealthPage() {
                 <Stat label="inflight futures" value={String(snap.cache.api_inflight ?? "—")} />
                 <Stat label="analysis jobs" value={String(snap.cache.analysis_jobs ?? "—")} />
               </div>
-            ) : <div className="text-xs text-slate-400">loading…</div>}
+            ) : <div className="text-xs text-slate-500">loading…</div>}
           </Card>
         </div>
 
         {/* Pipelines + Celery + Confirmation SLA */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <Card title={`Background jobs (${snap?.pipelines?.count ?? 0})`}>
-            <div className="text-xs space-y-2">
-              {!snap?.pipelines?.inflight?.length && <div className="text-slate-400">none running</div>}
+            <div className="text-xs space-y-2 text-slate-800">
+              {!snap?.pipelines?.inflight?.length && <div className="text-slate-500">none running</div>}
               {snap?.pipelines?.inflight?.map((p: any) => {
                 const stale = (p.age_s ?? 0) >= (snap.config?.pipeline_stale_s ?? 1800)
                 return (
-                  <div key={p.id} className={`border rounded p-2 ${stale ? "border-red-300 bg-red-50" : ""}`}>
+                  <div key={p.id} className={`border rounded p-2 ${stale ? "border-red-300 bg-red-50" : "bg-white"}`}>
                     <div className="font-mono text-[10px] text-slate-500">{p.kind}</div>
-                    <div className="truncate">{p.label}</div>
-                    <div className="text-slate-500">age {fmtDuration(p.age_s)}{p.store ? ` · ${p.store}` : ""}</div>
+                    <div className="truncate text-slate-900">{p.label}</div>
+                    <div className="text-slate-600">age {fmtDuration(p.age_s)}{p.store ? ` · ${p.store}` : ""}</div>
                   </div>
                 )
               })}
@@ -305,45 +382,45 @@ export default function SystemHealthPage() {
 
           <Card title="Celery worker">
             {snap?.celery ? (
-              <div className="text-xs space-y-1">
+              <div className="text-xs space-y-1 text-slate-800">
                 <div>
-                  broker:{" "}
-                  <span className={snap.celery.broker_ok === true ? "text-emerald-700" : snap.celery.broker_ok === false ? "text-red-600 font-semibold" : "text-slate-500"}>
+                  <span className="text-slate-500">broker:</span>{" "}
+                  <span className={snap.celery.broker_ok === true ? "text-emerald-700 font-semibold" : snap.celery.broker_ok === false ? "text-red-600 font-semibold" : "text-slate-600"}>
                     {snap.celery.broker_ok === true ? "ok" : snap.celery.broker_ok === false ? "down" : "?"}
                   </span>
                 </div>
-                <div className="text-slate-500 truncate">{snap.celery.broker_url || "—"}</div>
-                <div>queue depth: <span className="tabular-nums">{snap.celery.queue_depth ?? "—"}</span></div>
-                <div>active workers: <span className="tabular-nums">{snap.celery.active_workers ?? "—"}</span></div>
+                <div className="text-slate-500 truncate" title={snap.celery.broker_url || ""}>{snap.celery.broker_url || "—"}</div>
+                <div><span className="text-slate-500">queue depth:</span> <span className="tabular-nums text-slate-900">{snap.celery.queue_depth ?? "—"}</span></div>
+                <div><span className="text-slate-500">active workers:</span> <span className="tabular-nums text-slate-900">{snap.celery.active_workers ?? "—"}</span></div>
                 {snap.celery.last_error && <div className="text-red-600 truncate" title={snap.celery.last_error}>{snap.celery.last_error}</div>}
               </div>
-            ) : <div className="text-xs text-slate-400">loading…</div>}
+            ) : <div className="text-xs text-slate-500">loading…</div>}
           </Card>
 
           <Card title="Confirmation SLA">
             {snap?.confirmation ? (
-              <div className="text-xs space-y-1">
+              <div className="text-xs space-y-1 text-slate-800">
                 {snap.confirmation.pending ? (
                   <div className="text-slate-500">first scan in progress…</div>
                 ) : snap.confirmation.error ? (
                   <div className="text-red-600 truncate" title={snap.confirmation.error}>{snap.confirmation.error}</div>
                 ) : (
                   <>
-                    <div className="text-2xl font-bold tabular-nums">{snap.confirmation.stuck_total ?? 0}</div>
-                    <div className="text-slate-500">open + assigned orders without n/wtp action older than {snap.confirmation.cutoff_hours}h</div>
+                    <div className="text-2xl font-bold tabular-nums text-slate-900">{snap.confirmation.stuck_total ?? 0}</div>
+                    <div className="text-slate-600">open + assigned orders without n/wtp action older than {snap.confirmation.cutoff_hours}h</div>
                     {snap.confirmation.by_store && (
-                      <div className="space-y-0.5 mt-2">
+                      <div className="space-y-0.5 mt-2 text-slate-800">
                         {Object.entries(snap.confirmation.by_store).map(([store, v]: any) => (
                           <div key={store} className="font-mono">{store}: {v.error ? <span className="text-red-600">{v.error}</span> : <>stuck {v.stuck} / scanned {v.scanned}{v.truncated ? " (truncated)" : ""}</>}</div>
                         ))}
                       </div>
                     )}
-                    <div className="text-slate-400">checked {fmtTime(snap.confirmation.checked_at)}</div>
+                    <div className="text-slate-500">checked {fmtTime(snap.confirmation.checked_at)}</div>
                   </>
                 )}
-                <button onClick={() => systemHealthRefreshConfirmation().then(fetchAll)} className="mt-1 text-[11px] rounded border px-2 py-0.5 hover:bg-slate-50">Force refresh</button>
+                <button onClick={() => systemHealthRefreshConfirmation().then(fetchAll)} className="mt-1 text-[11px] rounded border px-2 py-0.5 hover:bg-slate-50 text-slate-700">Force refresh</button>
               </div>
-            ) : <div className="text-xs text-slate-400">loading…</div>}
+            ) : <div className="text-xs text-slate-500">loading…</div>}
           </Card>
         </div>
 
@@ -380,9 +457,9 @@ export default function SystemHealthPage() {
               <div className="text-[10px] uppercase text-slate-500 mb-1">overall</div>
               <SummaryStats s={snap?.db?.summary} />
               {snap?.db?.pool && (
-                <div className="mt-2 text-xs space-y-0.5">
-                  <div><span className="text-slate-500">pool class</span> {snap.db.pool.class}</div>
-                  <div><span className="text-slate-500">size</span> {snap.db.pool.size ?? "—"} <span className="text-slate-500 ml-2">checked out</span> {snap.db.pool.checked_out ?? "—"} <span className="text-slate-500 ml-2">overflow</span> {snap.db.pool.overflow ?? "—"}</div>
+                <div className="mt-2 text-xs space-y-0.5 text-slate-800">
+                  <div><span className="text-slate-500">pool class</span> <span className="text-slate-900">{snap.db.pool.class}</span></div>
+                  <div><span className="text-slate-500">size</span> <span className="text-slate-900">{snap.db.pool.size ?? "—"}</span> <span className="text-slate-500 ml-2">checked out</span> <span className="text-slate-900">{snap.db.pool.checked_out ?? "—"}</span> <span className="text-slate-500 ml-2">overflow</span> <span className="text-slate-900">{snap.db.pool.overflow ?? "—"}</span></div>
                 </div>
               )}
             </div>
@@ -397,7 +474,7 @@ export default function SystemHealthPage() {
         <Card title="Requests by surface">
           {snap?.request?.by_surface && Object.keys(snap.request.by_surface).length > 0 ? (
             <div className="overflow-x-auto">
-              <table className="w-full text-xs tabular-nums">
+              <table className="w-full text-xs tabular-nums text-slate-800">
                 <thead className="text-left text-slate-500">
                   <tr>
                     <th className="py-1 pr-2 font-normal">surface</th>
@@ -412,7 +489,7 @@ export default function SystemHealthPage() {
                 <tbody>
                   {Object.entries(snap.request.by_surface).map(([surface, s]: any) => (
                     <tr key={surface} className="border-t">
-                      <td className="py-1 pr-2 font-mono">{surface}</td>
+                      <td className="py-1 pr-2 font-mono text-slate-800">{surface}</td>
                       <td className="py-1 px-1 text-right">{s.count}</td>
                       <td className="py-1 px-1 text-right">{fmtMs(s.p50)}</td>
                       <td className="py-1 px-1 text-right">{fmtMs(s.p95)}</td>
@@ -424,7 +501,7 @@ export default function SystemHealthPage() {
                 </tbody>
               </table>
             </div>
-          ) : <div className="text-xs text-slate-400">no requests sampled yet</div>}
+          ) : <div className="text-xs text-slate-500">no requests sampled yet</div>}
         </Card>
 
         {/* Slowest individual routes */}
@@ -436,7 +513,7 @@ export default function SystemHealthPage() {
         <Card title="Slow ops feed (top 50, sorted by duration)">
           {snap?.slow_ops?.length ? (
             <div className="overflow-x-auto">
-              <table className="w-full text-xs tabular-nums">
+              <table className="w-full text-xs tabular-nums text-slate-800">
                 <thead className="text-left text-slate-500">
                   <tr>
                     <th className="py-1 pr-2 font-normal">time</th>
@@ -451,20 +528,20 @@ export default function SystemHealthPage() {
                   {snap.slow_ops.map((r: any, i: number) => (
                     <tr key={i} className={`border-t ${!r.ok ? "bg-red-50" : ""}`}>
                       <td className="py-1 pr-2 text-slate-500">{fmtTime(r.ts)}</td>
-                      <td className="py-1 px-1 font-mono">{r.category}</td>
-                      <td className="py-1 px-1 truncate max-w-[260px]" title={r.op}>{r.op}</td>
-                      <td className="py-1 px-1 text-right">{fmtMs(r.ms)}</td>
-                      <td className="py-1 px-1">{r.store || ""}</td>
+                      <td className="py-1 px-1 font-mono text-slate-700">{r.category}</td>
+                      <td className="py-1 px-1 truncate max-w-[260px] text-slate-800" title={r.op}>{r.op}</td>
+                      <td className="py-1 px-1 text-right text-slate-900">{fmtMs(r.ms)}</td>
+                      <td className="py-1 px-1 text-slate-700">{r.store || ""}</td>
                       <td className="py-1 px-1 text-red-600 truncate max-w-[280px]" title={r.error || ""}>{r.error || ""}</td>
                     </tr>
                   ))}
                 </tbody>
               </table>
             </div>
-          ) : <div className="text-xs text-slate-400">no samples yet</div>}
+          ) : <div className="text-xs text-slate-500">no samples yet</div>}
         </Card>
 
-        <div className="text-[10px] text-slate-400 pb-6">
+        <div className="text-[10px] text-slate-500 pb-6">
           window: last {Math.round((snap?.config?.window_s || 600) / 60)} min · ring size {snap?.config?.ring_size} · in-memory only (resets on instance recycle)
         </div>
       </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1404,3 +1404,8 @@ export async function systemHealthRefreshConfirmation(){
   return data as { data?: any, error?: string }
 }
 
+export async function systemHealthClearIncidents(){
+  const { data } = await axios.post(`${base}/api/system-health/incidents/clear`, {}, { headers: { ...systemAdminHeaders() } })
+  return data as { data?: { cleared: number }, error?: string }
+}
+


### PR DESCRIPTION
The frontend globals.css applies color:#e6e8ef to body unconditionally, which made every Tailwind-styled element on /system-health render as white-on-white. Set explicit dark text colors throughout the page, stats, tables, and inline labels.

Add an in-memory incident log so warn/crit reasons stay visible after the conditions resolve. Each incident tracks first_seen, last_seen, resolved_at, level, code, message, and a tick_count for how often the status pass observed it. The log is keyed by code so flapping doesn't spam entries; a re-open after resolution starts a fresh incident.

A daemon poller calls status() every HEALTH_INCIDENT_POLLER_S (default 60s) so issues are recorded even when nobody is watching the dashboard, and the next admin to open the page sees what happened with timestamps. The dashboard now shows an "Incident log" card right after the status badge with a Clear-history action.